### PR TITLE
cmake: Support sourcing NRFXLIB_DIR without having GCC_M_CPU set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,22 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-if(CONFIG_FLOAT)
-  if(CONFIG_FP_HARDABI)
-    set(float_dir hard-float)
-  elseif(CONFIG_FP_SOFTABI)
-    set(float_dir softfp-float)
-  else()
-    assert(0 "Unreachable code")
-  endif()
-else()
-  set(float_dir soft-float)
-endif()
-
-assert(GCC_M_CPU "GCC_M_CPU must be set to find correct lib.")
-
-set(lib_path lib/${GCC_M_CPU}/${float_dir})
-
 add_subdirectory_ifdef(CONFIG_NRFXLIB_NFC    nfc)
 add_subdirectory_ifdef(CONFIG_BT_LL_NRFXLIB  ble_controller)
 add_subdirectory_ifdef(CONFIG_BSD_LIBRARY    bsdlib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-if (${CONFIG_FLOAT})
+if(CONFIG_FLOAT)
   if(CONFIG_FP_HARDABI)
     set(float_dir hard-float)
   elseif(CONFIG_FP_SOFTABI)
@@ -12,11 +12,12 @@ if (${CONFIG_FLOAT})
   else()
     assert(0 "Unreachable code")
   endif()
-else ()
+else()
   set(float_dir soft-float)
 endif()
 
 assert(GCC_M_CPU "GCC_M_CPU must be set to find correct lib.")
+
 set(lib_path lib/${GCC_M_CPU}/${float_dir})
 
 add_subdirectory_ifdef(CONFIG_NRFXLIB_NFC    nfc)

--- a/ble_controller/CMakeLists.txt
+++ b/ble_controller/CMakeLists.txt
@@ -4,6 +4,10 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
+include(${NRFXLIB_DIR}/common.cmake)
+
+nrfxlib_calculate_lib_path(lib_path)
+
 set(BLE_CONTROLLER_LIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${lib_path})
 
 if(NOT EXISTS ${BLE_CONTROLLER_LIB_PATH})

--- a/bsdlib/CMakeLists.txt
+++ b/bsdlib/CMakeLists.txt
@@ -4,6 +4,10 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
+include(${NRFXLIB_DIR}/common.cmake)
+
+nrfxlib_calculate_lib_path(lib_path)
+
 set(BSD_LIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${lib_path})
 
 if(NOT EXISTS ${BSD_LIB_PATH})

--- a/common.cmake
+++ b/common.cmake
@@ -1,0 +1,23 @@
+# Header guard
+if(__NRFXLIB_COMMON_CMAKE__)
+  return()
+endif()
+set(__NRFXLIB_COMMON_CMAKE__ TRUE)
+
+function(nrfxlib_calculate_lib_path lib_path)
+  if(CONFIG_FLOAT)
+	if(CONFIG_FP_HARDABI)
+      set(float_dir hard-float)
+	elseif(CONFIG_FP_SOFTABI)
+      set(float_dir softfp-float)
+	else()
+      assert(0 "Unreachable code")
+	endif()
+  else()
+	set(float_dir soft-float)
+  endif()
+
+  assert(GCC_M_CPU "GCC_M_CPU must be set to find correct lib.")
+
+  set(${lib_path} lib/${GCC_M_CPU}/${float_dir} PARENT_SCOPE)
+endfunction()

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -4,6 +4,10 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
+include(${NRFXLIB_DIR}/common.cmake)
+
+nrfxlib_calculate_lib_path(lib_path)
+
 zephyr_interface_library_named(nrfxlib_crypto)
 
 if (CONFIG_NRF_OBERON)

--- a/nfc/CMakeLists.txt
+++ b/nfc/CMakeLists.txt
@@ -4,6 +4,10 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
+include(${NRFXLIB_DIR}/common.cmake)
+
+nrfxlib_calculate_lib_path(lib_path)
+
 set(NFC_LIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${lib_path})
 
 if(NOT EXISTS ${NFC_LIB_PATH})

--- a/nfc/CMakeLists.txt
+++ b/nfc/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-set(NFC_LIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/lib/${GCC_M_CPU}/${float_dir})
+set(NFC_LIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${lib_path})
 
 if(NOT EXISTS ${NFC_LIB_PATH})
   message(WARNING "This combination of SoC and floating point ABI is not supported by the nfc lib."


### PR DESCRIPTION
Support having a 'nrfxlib' directory present without having
'GCC_M_CPU'. As the build scripts were written before, nrfxlib build
scripts would run code that was not relevant to builds that did not
actually use any nrfxlib components.

This has been resolved by moving code from the root
'nrfxlib/CMakeLists.txt' and into the subdirectories that are only
included when their components are enabled through Kconfig.

This re-organization allows the 'nrfxlib' directory to be present
while doing non-nrfxlib builds, like x86 builds for instance.

The code is now written such that 'nrfxlib' modules include the
relevant common 'nrfxlib' code that they need, as opposed to having
common build script code be executed before 'nrfxlib' modules are
executed.