### PR TITLE
bsdlib: Add NRF_SO_ERROR and NRF_SO_BINDTODEVICE

### DIFF
--- a/bsdlib/include/nrf_socket.h
+++ b/bsdlib/include/nrf_socket.h
@@ -119,7 +119,9 @@ typedef int32_t ssize_t;
  * @ingroup nrf_socket
  * @{
  */
+#define NRF_SO_ERROR                    4
 #define NRF_SO_RCVTIMEO                 20
+#define NRF_SO_BINDTODEVICE             25
 /**@} */
 
 /**@defgroup nrf_socket_options_levels Values for Socket option levels


### PR DESCRIPTION
Implementation in bsdlib will come in a later update of the lib.

Signed-off-by: Stig Bjørlykke <stig.bjorlykke@nordicsemi.no>