### PR TITLE
build: Switch to using Zephyr modules to include the repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
+set(NRFXLIB_DIR ${CMAKE_CURRENT_LIST_DIR})
 add_subdirectory_ifdef(CONFIG_NRFXLIB_NFC    nfc)
 add_subdirectory_ifdef(CONFIG_BT_LL_NRFXLIB  ble_controller)
 add_subdirectory_ifdef(CONFIG_BSD_LIBRARY    bsdlib)

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,3 @@
+build:
+  cmake: .
+  kconfig: Kconfig.nrfxlib


### PR DESCRIPTION
In order to include the repository in the Zephyr build, we used to rely
on a custom hook in the zephyr repository's root CMakeLists.txt and
Kconfig.zephyr files, which included the nrf/ repository and this in
turn included the present nrfxlib/ one. Now that Zephyr natively supports
external modules, use this mechanism to include nrfxlib in the Zephyr build
without relying on the nrf repository.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>