### PR TITLE
bsdlib: Define missing nrf_errno doxygen group

### DIFF
--- a/bsdlib/include/nrf_errno.h
+++ b/bsdlib/include/nrf_errno.h
@@ -10,6 +10,8 @@
  * @file nrf_errno.h
  * @brief Defines integer values for errno.
  *        Used by system calls to indicates the latest error.
+ *
+ * @defgroup nrf_errno
  */
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Documentation build throw warning because of this.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>