### PR TITLE
crypto: cmake: Add support for multi-image build of crypto

### DIFF
--- a/bsdlib/CMakeLists.txt
+++ b/bsdlib/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 # command line.
 zephyr_link_libraries(
   ${BSD_LIB_PATH}/libbsd_nrf9160_xxaa.a
-  nrfxlib_crypto
+  ${IMAGE}nrfxlib_crypto
   c
   )
 

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -18,8 +18,8 @@ if (CONFIG_NRF_OBERON)
     message(WARNING "This combination of SoC and floating point ABI is not supported by the nrf_oberon lib."
                     "(${OBERON_LIB} doesn't exist.)")
   endif()
-  target_include_directories(nrfxlib_crypto INTERFACE ${OBERON_BASE}/include)
-  target_link_libraries(nrfxlib_crypto INTERFACE ${OBERON_LIB})
+  target_include_directories(${IMAGE}nrfxlib_crypto INTERFACE ${OBERON_BASE}/include)
+  target_link_libraries(${IMAGE}nrfxlib_crypto INTERFACE ${OBERON_LIB})
 endif()
 
 if (CONFIG_NRF_CC310_BL)
@@ -34,8 +34,8 @@ if (CONFIG_NRF_CC310_BL)
     message(WARNING "This combination of SoC, floating point ABI, and interrupts settings is not supported by the nrf_cc310_bl lib."
                     "(${CC310_BL_LIB} doesn't exist.)")
   endif()
-  target_include_directories(nrfxlib_crypto INTERFACE ${CC310_BL_BASE}/include)
-  target_link_libraries(nrfxlib_crypto INTERFACE ${CC310_BL_LIB})
+  target_include_directories(${IMAGE}nrfxlib_crypto INTERFACE ${CC310_BL_BASE}/include)
+  target_link_libraries(${IMAGE}nrfxlib_crypto INTERFACE ${CC310_BL_LIB})
 endif()
 
 if (NOT CONFIG_NRF_OBERON AND NOT CONFIG_NRF_CC310_BL)


### PR DESCRIPTION
This change adds support for building multi-image builds with crypto
interfaces such as cc310 and oberon. This will not break anything for
other builds as `${IMAGE}` will be resolved to ` `.

Signed-off-by: Sigvart Hovland <sigvart.m@gmail.com>