### PR TITLE
nrf_oberon: Remove non-existing doc references

### DIFF
--- a/crypto/doc/api.rst
+++ b/crypto/doc/api.rst
@@ -9,13 +9,3 @@ nRF cc310 bootloader crypto library
 .. doxygengroup:: nrf_cc310_bl
    :project: nrfxlib
    :members:
-
-nRF Oberon crypto library
-*************************
-
-.. doxygengroup:: nrf_oberon
-   :project: nrfxlib
-   :members:
-
-
-


### PR DESCRIPTION
This is a showstopper for `nrfxlib` version update in https://github.com/NordicPlayground/fw-nrfconnect-nrf as it triggers CI failure.

`nrf_oberon` group is no longer present, therefore it cannot be referenced.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>