### PR TITLE
doc: ble_controller: Document known toolchain issue

### DIFF
--- a/ble_controller/README.rst
+++ b/ble_controller/README.rst
@@ -28,6 +28,7 @@ Each library is distributed in soft-float, softfp-float, and hard-float builds.
   * The libraries are for evaluation purposes only.
   * The libraries are not fully functional.
   * The libraries are not built for performance.
+  * Some toolchains cause a segmentation fault when linking the libraries.
 
 
 .. toctree::


### PR DESCRIPTION
Certain toolchains are known to segfault when linking with the
ble_controller library.

It is not known exactly which set of toolchains segfault. It is
believed to affect all NCS revisions as of april 2019.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>