### PR TITLE
bsdlib: Add missing empty line to the changelog

### DIFF
--- a/bsdlib/CHANGELOG.rst
+++ b/bsdlib/CHANGELOG.rst
@@ -9,6 +9,7 @@ bsdlib 0.2.4
 ************
 
 Updated library with bug fixes:
+
 * Fix issue of reporting NRF_POLLIN on a socket handle using nrf_poll, even if no new data has arrived.
 * Fix issue of sockets not blocking on recv/recvfrom when no data is available.
 


### PR DESCRIPTION
An empty line was missing before the bullet points, messing up the
layout.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>