### PR TITLE
libbsd: bsd lib is now an imported target

### DIFF
--- a/bsdlib/CMakeLists.txt
+++ b/bsdlib/CMakeLists.txt
@@ -19,10 +19,12 @@ endif()
 # lib oberon are linked in because they are used by the bsd library
 # and must therefore be placed after the bsd library on the linker's
 # command line.
-zephyr_link_libraries(
-  ${BSD_LIB_PATH}/libbsd_nrf9160_xxaa.a
-  ${IMAGE}nrfxlib_crypto
-  c
-  )
+set(BSDLIB_TARGET ${IMAGE}bsd_nrf9160_xxaa)
+add_library(${BSDLIB_TARGET} STATIC IMPORTED GLOBAL)
+set_target_properties(${BSDLIB_TARGET} PROPERTIES IMPORTED_LOCATION
+                      "${BSD_LIB_PATH}/libbsd_nrf9160_xxaa.a"
+)
+target_link_libraries(${BSDLIB_TARGET} INTERFACE ${IMAGE}nrfxlib_crypto -lc)
+zephyr_link_libraries(${BSDLIB_TARGET})
 
 zephyr_include_directories(include)


### PR DESCRIPTION
Making liboberon to an imported target.

To ensure the ordering of linking when using both libbsd and liboberon, the bsd lib is now setting oberon as link library interface to ensure oberon will follow during final linking and thus symbols can be correctly resolved.


Signed-off-by: Torsten Rasmussen <torsten.rasmussen@nordicsemi.no>