### PR TITLE
Platform zeroize fix - glue symbol naming fix

### DIFF
--- a/nrf_security/cmake/symbol_rename.cmake
+++ b/nrf_security/cmake/symbol_rename.cmake
@@ -42,6 +42,7 @@ function(library_redefine_symbols backend template)
   keep_config_test_glue("MBEDTLS_ECDH_C"          ${BACKEND_NAME})
   keep_config_test_glue("MBEDTLS_ECDSA_C"         ${BACKEND_NAME})
   keep_config_test_glue("MBEDTLS_GCM_C"           ${BACKEND_NAME})
+  keep_config_test("MBEDTLS_PLATFORM"             ${BACKEND_NAME})
   
   string(TOLOWER "${backend}" MBEDTLS_BACKEND_PREFIX)
   configure_file(${template}

--- a/nrf_security/include/mbedcrypto_glue/mbedtls/aes_alt.h
+++ b/nrf_security/include/mbedcrypto_glue/mbedtls/aes_alt.h
@@ -18,7 +18,7 @@
 #endif
 
 #define CC310_MBEDTLS_AES_CONTEXT_WORDS         (24)    //!< AES context size in words in nrf_cc310_mbedcrypto library.
-#define VANILLA_MBEDTLS_AES_CONTEXT_WORDS       (70)    //!< AES context size in words in standard mbed TLS.
+#define VANILLA_MBEDTLS_AES_CONTEXT_WORDS       (76)    //!< AES context size in words in standard mbed TLS.
 #define VANILLA_MBEDTLS_AES_XTS_CONTEXT_WORDS   (140)   //!< AES XTS context size in words in standard mbed TLS.
 
 #if defined(MBEDTLS_AES_ALT)

--- a/nrf_security/src/mbedcrypto_glue/CMakeLists.txt
+++ b/nrf_security/src/mbedcrypto_glue/CMakeLists.txt
@@ -43,6 +43,10 @@ else()
   add_library(mbedcrypto_glue INTERFACE)
 endif()
 
+# Platform implementation cannot be chosen Kconfig.
+# To ensure platform symbols are not renamed cc310 implementation is used.
+set(CONFIG_CC310_MBEDTLS_PLATFORM True)
+
 library_redefine_symbols("cc310" ${CMAKE_CURRENT_LIST_DIR}/symbol_rename.template.txt)
 library_redefine_symbols("vanilla" ${CMAKE_CURRENT_LIST_DIR}/symbol_rename.template.txt)
 

--- a/nrf_security/src/mbedcrypto_glue/cc310/CMakeLists.txt
+++ b/nrf_security/src/mbedcrypto_glue/cc310/CMakeLists.txt
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 if(CONFIG_CC310_BACKEND)
-  set(cc310_backend_glue_src
+  zephyr_library_named(mbedcrypto_glue_cc310)
+  zephyr_library_sources(
       ${CMAKE_CURRENT_LIST_DIR}/aes_cc310.c
       ${CMAKE_CURRENT_LIST_DIR}/ccm_cc310.c
       ${CMAKE_CURRENT_LIST_DIR}/cmac_cc310.c
@@ -13,15 +14,10 @@ if(CONFIG_CC310_BACKEND)
       ${CMAKE_CURRENT_LIST_DIR}/ecdsa_cc310.c
       ${CMAKE_CURRENT_LIST_DIR}/rsa_cc310.c
   )
-  
-  set_source_files_properties(${cc310_backend_glue_src}
-                              PROPERTIES COMPILE_DEFINITIONS MBEDTLS_BACKEND_PREFIX=cc310)
+  zephyr_library_compile_definitions(MBEDTLS_BACKEND_PREFIX=cc310)
 
-  add_library(mbedcrypto_glue_cc310 STATIC ${cc310_backend_glue_src})
-  target_include_directories(mbedcrypto_glue_cc310 PRIVATE
-                             $<TARGET_PROPERTY:mbedcrypto_glue,INCLUDE_DIRECTORIES>)
-  target_compile_definitions(mbedcrypto_glue_cc310 PRIVATE
-                             $<TARGET_PROPERTY:mbedcrypto_glue,COMPILE_DEFINITIONS>)
+  zephyr_library_include_directories($<TARGET_PROPERTY:mbedcrypto_glue,INCLUDE_DIRECTORIES>)
+  zephyr_library_compile_definitions($<TARGET_PROPERTY:mbedcrypto_glue,COMPILE_DEFINITIONS>)
   add_custom_command(
     TARGET mbedcrypto_glue_cc310
     POST_BUILD
@@ -30,5 +26,4 @@ if(CONFIG_CC310_BACKEND)
             ${CMAKE_CURRENT_BINARY_DIR}/symbol_rename_cc310.txt
             $<TARGET_FILE:mbedcrypto_glue_cc310>
   )
-  target_link_libraries(mbedcrypto_glue PRIVATE mbedcrypto_glue_cc310)
 endif()

--- a/nrf_security/src/mbedcrypto_glue/cc310/aes_cc310.c
+++ b/nrf_security/src/mbedcrypto_glue/cc310/aes_cc310.c
@@ -20,9 +20,9 @@ static int mbedtls_aes_check(unsigned int keybits, int mode, int xts)
 }
 
 const mbedtls_aes_funcs mbedtls_aes_cc310_backend_funcs = {
-    .backend_context_size = (4 * MBEDTLS_CC310_AES_CONTEXT_WORDS),
+    .backend_context_size = (4 * CC310_MBEDTLS_AES_CONTEXT_WORDS),
 #if defined(CONFIG_CC310_MBEDTLS_CIPHER_MODE_XTS) && defined(CONFIG_GLUE_MBEDTLS_CIPHER_MODE_XTS)
-    .backend_xts_context_size = (4 * MBEDTLS_CC310_AES_XTS_CONTEXT_WORDS),
+    .backend_xts_context_size = (4 * CC310_MBEDTLS_AES_XTS_CONTEXT_WORDS),
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
     .check = mbedtls_aes_check,
     .init = mbedtls_aes_init,

--- a/nrf_security/src/mbedcrypto_glue/cc310/ccm_cc310.c
+++ b/nrf_security/src/mbedcrypto_glue/cc310/ccm_cc310.c
@@ -21,7 +21,7 @@ static int mbedtls_ccm_check(mbedtls_cipher_id_t cipher, unsigned int keybits)
 }
 
 const mbedtls_ccm_funcs mbedtls_ccm_cc310_backend_funcs = {
-    .backend_context_size = (4 * MBEDTLS_CC310_CCM_CONTEXT_WORDS),
+    .backend_context_size = (4 * CC310_MBEDTLS_CCM_CONTEXT_WORDS),
     .check = mbedtls_ccm_check,
     .init = mbedtls_ccm_init,
     .setkey = mbedtls_ccm_setkey,

--- a/nrf_security/src/mbedcrypto_glue/cc310/rsa_cc310.c
+++ b/nrf_security/src/mbedcrypto_glue/cc310/rsa_cc310.c
@@ -25,7 +25,7 @@ static int mbedtls_rsa_check(int padding, int hash_id, unsigned int nbits)
 }
 
 const mbedtls_rsa_funcs mbedtls_rsa_cc310_backend_funcs = {
-    .backend_context_size = (4 * MBEDTLS_CC310_RSA_CONTEXT_WORDS),
+    .backend_context_size = (4 * CC310_MBEDTLS_RSA_CONTEXT_WORDS),
     .check = mbedtls_rsa_check,
     .init = mbedtls_rsa_init,
     .import = mbedtls_rsa_import,

--- a/nrf_security/src/mbedcrypto_glue/ecdsa_alt.c
+++ b/nrf_security/src/mbedcrypto_glue/ecdsa_alt.c
@@ -24,7 +24,7 @@
 extern mbedtls_ecdsa_funcs mbedtls_ecdsa_cc310_backend_funcs;
 #endif
 #if defined(CONFIG_VANILLA_MBEDTLS_ECDSA_C)
-extern mbedtls_ecdsa_funcs mbedtls_ecdsa_default_backend_funcs;
+extern mbedtls_ecdsa_funcs mbedtls_ecdsa_vanilla_mbedtls_backend_funcs;
 #endif
 
 
@@ -33,7 +33,7 @@ static mbedtls_ecdsa_funcs* ecdsa_backends[] = {
     &mbedtls_ecdsa_cc310_backend_funcs,
 #endif
 #if defined(CONFIG_VANILLA_MBEDTLS_ECDSA_C)
-    &mbedtls_ecdsa_default_backend_funcs,
+    &mbedtls_ecdsa_vanilla_mbedtls_backend_funcs,
 #endif
 };
 

--- a/nrf_security/src/mbedcrypto_glue/symbol_rename.template.txt
+++ b/nrf_security/src/mbedcrypto_glue/symbol_rename.template.txt
@@ -106,25 +106,4 @@ ${KEEP_MBEDTLS_GCM_C}mbedtls_gcm_init ${MBEDTLS_BACKEND_PREFIX}_mbedtls_gcm_init
 ${KEEP_MBEDTLS_GCM_C}mbedtls_gcm_setkey ${MBEDTLS_BACKEND_PREFIX}_mbedtls_gcm_setkey
 ${KEEP_MBEDTLS_GCM_C}mbedtls_gcm_starts ${MBEDTLS_BACKEND_PREFIX}_mbedtls_gcm_starts
 ${KEEP_MBEDTLS_GCM_C}mbedtls_gcm_update ${MBEDTLS_BACKEND_PREFIX}_mbedtls_gcm_update
-## cipher.o is available in all backends and no _ALT to ensure only single
-## backend has the symbols. Thus rename, to ensure uniqueness
-${KEEP_MBEDTLS_CIPHER}mbedtls_cipher_list ${MBEDTLS_BACKEND_PREFIX}_mbedtls_cipher_list
-${KEEP_MBEDTLS_CIPHER}mbedtls_cipher_info_from_type ${MBEDTLS_BACKEND_PREFIX}_mbedtls_cipher_info_from_type
-${KEEP_MBEDTLS_CIPHER}mbedtls_cipher_info_from_string ${MBEDTLS_BACKEND_PREFIX}_mbedtls_cipher_info_from_string
-${KEEP_MBEDTLS_CIPHER}mbedtls_cipher_info_from_values ${MBEDTLS_BACKEND_PREFIX}_mbedtls_cipher_info_from_values
-${KEEP_MBEDTLS_CIPHER}mbedtls_cipher_init ${MBEDTLS_BACKEND_PREFIX}_mbedtls_cipher_init
-${KEEP_MBEDTLS_CIPHER}mbedtls_cipher_free ${MBEDTLS_BACKEND_PREFIX}_mbedtls_cipher_free
-${KEEP_MBEDTLS_CIPHER}mbedtls_cipher_setup ${MBEDTLS_BACKEND_PREFIX}_mbedtls_cipher_setup
-${KEEP_MBEDTLS_CIPHER}mbedtls_cipher_set_padding_mode ${MBEDTLS_BACKEND_PREFIX}_mbedtls_cipher_set_padding_mode
-${KEEP_MBEDTLS_CIPHER}mbedtls_cipher_setkey ${MBEDTLS_BACKEND_PREFIX}_mbedtls_cipher_setkey
-${KEEP_MBEDTLS_CIPHER}mbedtls_cipher_set_iv ${MBEDTLS_BACKEND_PREFIX}_mbedtls_cipher_set_iv
-${KEEP_MBEDTLS_CIPHER}mbedtls_cipher_reset ${MBEDTLS_BACKEND_PREFIX}_mbedtls_cipher_reset
-${KEEP_MBEDTLS_CIPHER}mbedtls_cipher_update_ad ${MBEDTLS_BACKEND_PREFIX}_mbedtls_cipher_update_ad
-${KEEP_MBEDTLS_CIPHER}mbedtls_cipher_update ${MBEDTLS_BACKEND_PREFIX}_mbedtls_cipher_update
-${KEEP_MBEDTLS_CIPHER}mbedtls_cipher_finish ${MBEDTLS_BACKEND_PREFIX}_mbedtls_cipher_finish
-${KEEP_MBEDTLS_CIPHER}mbedtls_cipher_write_tag ${MBEDTLS_BACKEND_PREFIX}_mbedtls_cipher_write_tag
-${KEEP_MBEDTLS_CIPHER}mbedtls_cipher_check_tag ${MBEDTLS_BACKEND_PREFIX}_mbedtls_cipher_check_tag
-${KEEP_MBEDTLS_CIPHER}mbedtls_cipher_crypt ${MBEDTLS_BACKEND_PREFIX}_mbedtls_cipher_crypt
-${KEEP_MBEDTLS_CIPHER}mbedtls_cipher_auth_encrypt ${MBEDTLS_BACKEND_PREFIX}_mbedtls_cipher_auth_encrypt
-${KEEP_MBEDTLS_CIPHER}mbedtls_cipher_auth_decrypt ${MBEDTLS_BACKEND_PREFIX}_mbedtls_cipher_auth_decrypt
-mbedtls_platform_zeroize ${MBEDTLS_BACKEND_PREFIX}_mbedtls_platform_zeroize
+${KEEP_MBEDTLS_PLATFORM}mbedtls_platform_zeroize ${MBEDTLS_BACKEND_PREFIX}_mbedtls_platform_zeroize

--- a/nrf_security/src/mbedcrypto_glue/vanilla/CMakeLists.txt
+++ b/nrf_security/src/mbedcrypto_glue/vanilla/CMakeLists.txt
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 if (CONFIG_MBEDTLS_VANILLA_BACKEND)
-  set(vanilla_backend_glue_src
+  zephyr_library_named(mbedcrypto_glue_vanilla)
+  zephyr_library_sources(
       ${CMAKE_CURRENT_LIST_DIR}/aes_vanilla.c
       ${CMAKE_CURRENT_LIST_DIR}/ccm_vanilla.c
       ${CMAKE_CURRENT_LIST_DIR}/cmac_vanilla.c
@@ -13,14 +14,10 @@ if (CONFIG_MBEDTLS_VANILLA_BACKEND)
       ${CMAKE_CURRENT_LIST_DIR}/rsa_vanilla.c
   )
   
-  set_source_files_properties(${vanilla_backend_glue_src}
-                              PROPERTIES COMPILE_DEFINITIONS MBEDTLS_BACKEND_PREFIX=vanilla)
+  zephyr_library_compile_definitions(MBEDTLS_BACKEND_PREFIX=vanilla)
 
-  add_library(mbedcrypto_glue_vanilla STATIC ${vanilla_backend_glue_src})
-  target_include_directories(mbedcrypto_glue_vanilla PRIVATE
-                             $<TARGET_PROPERTY:mbedcrypto_glue,INCLUDE_DIRECTORIES>)
-  target_compile_definitions(mbedcrypto_glue_vanilla PRIVATE
-                             $<TARGET_PROPERTY:mbedcrypto_glue,COMPILE_DEFINITIONS>)
+  zephyr_library_include_directories($<TARGET_PROPERTY:mbedcrypto_glue,INCLUDE_DIRECTORIES>)
+  zephyr_library_compile_definitions($<TARGET_PROPERTY:mbedcrypto_glue,COMPILE_DEFINITIONS>)
   add_custom_command(
     TARGET mbedcrypto_glue_vanilla
     POST_BUILD
@@ -29,5 +26,4 @@ if (CONFIG_MBEDTLS_VANILLA_BACKEND)
             ${CMAKE_CURRENT_BINARY_DIR}/symbol_rename_vanilla.txt
             $<TARGET_FILE:mbedcrypto_glue_vanilla>
   )
-  target_link_libraries(mbedcrypto_glue PRIVATE mbedcrypto_glue_vanilla)
 endif()

--- a/nrf_security/src/mbedcrypto_glue/vanilla/aes_vanilla.c
+++ b/nrf_security/src/mbedcrypto_glue/vanilla/aes_vanilla.c
@@ -11,15 +11,15 @@
 
 #if defined(CONFIG_VANILLA_MBEDTLS_AES_C) && defined(CONFIG_GLUE_MBEDTLS_AES_C)
 
-#include <assert.h>
+#include <toolchain.h>
 
 #include "mbedtls/aes.h"
 #include "mbedtls/aes_alt.h"
 #include "backend_aes.h"
 
-static_assert(MBEDTLS_DEFAULT_AES_CONTEXT_WORDS == (sizeof(mbedtls_aes_context) - 4) / 4, "Invalid MBEDTLS_DEFAULT_AES_CONTEXT_WORDS value");
+BUILD_ASSERT_MSG(VANILLA_MBEDTLS_AES_CONTEXT_WORDS == (sizeof(mbedtls_aes_context) - 4) / 4, "Invalid VANILLA_MBEDTLS_AES_CONTEXT_WORDS value");
 #if defined(CONFIG_GLUE_MBEDTLS_CIPHER_MODE_XTS) && defined(CONFIG_VANILLA_MBEDTLS_CIPHER_MODE_XTS)
-static_assert(MBEDTLS_DEFAULT_AES_XTS_CONTEXT_WORDS == (sizeof(mbedtls_aes_xts_context) - 4) / 4, "Invalid MBEDTLS_DEFAULT_AES_XTS_CONTEXT_WORDS value");
+BUILD_ASSERT_MSG(VANILLA_MBEDTLS_AES_XTS_CONTEXT_WORDS == (sizeof(mbedtls_aes_xts_context) - 4) / 4, "Invalid VANILLA_MBEDTLS_AES_XTS_CONTEXT_WORDS value");
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
 
 
@@ -28,10 +28,10 @@ static int mbedtls_aes_check(unsigned int keybits, int mode, int xts)
     return 1;
 }
 
-const mbedtls_aes_funcs mbedtls_aes_default_backend_funcs = {
-    .backend_context_size = (4 * MBEDTLS_DEFAULT_AES_CONTEXT_WORDS),
+const mbedtls_aes_funcs mbedtls_aes_vanilla_mbedtls_backend_funcs = {
+    .backend_context_size = (4 * VANILLA_MBEDTLS_AES_CONTEXT_WORDS),
 #if defined(CONFIG_GLUE_MBEDTLS_CIPHER_MODE_XTS) && defined(CONFIG_VANILLA_MBEDTLS_CIPHER_MODE_XTS)
-    .backend_xts_context_size = (4 * MBEDTLS_DEFAULT_AES_XTS_CONTEXT_WORDS),
+    .backend_xts_context_size = (4 * VANILLA_MBEDTLS_AES_XTS_CONTEXT_WORDS),
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
     .check = mbedtls_aes_check,
     .init = mbedtls_aes_init,

--- a/nrf_security/src/mbedcrypto_glue/vanilla/ccm_vanilla.c
+++ b/nrf_security/src/mbedcrypto_glue/vanilla/ccm_vanilla.c
@@ -11,14 +11,14 @@
 
 #if defined(CONFIG_VANILLA_MBEDTLS_CCM_C) && defined(CONFIG_GLUE_MBEDTLS_CCM_C)
 
-#include <assert.h>
+#include <toolchain.h>
 
 #include "mbedtls/ccm.h"
 #include "mbedtls/ccm_alt.h"
 #include "backend_ccm.h"
 
 
-static_assert(MBEDTLS_DEFAULT_CCM_CONTEXT_WORDS == (sizeof(mbedtls_ccm_context) - 4 + 3) / 4, "Invalid MBEDTLS_DEFAULT_CCM_CONTEXT_WORDS value");
+BUILD_ASSERT_MSG(VANILLA_MBEDTLS_CCM_CONTEXT_WORDS == (sizeof(mbedtls_ccm_context) - 4 + 3) / 4, "Invalid VANILLA_MBEDTLS_CCM_CONTEXT_WORDS value");
 
 
 static int mbedtls_ccm_check(mbedtls_cipher_id_t cipher, unsigned int keybits)
@@ -26,8 +26,8 @@ static int mbedtls_ccm_check(mbedtls_cipher_id_t cipher, unsigned int keybits)
     return 1;
 }
 
-const mbedtls_ccm_funcs mbedtls_ccm_default_backend_funcs = {
-    .backend_context_size = (4 * MBEDTLS_DEFAULT_CCM_CONTEXT_WORDS),
+const mbedtls_ccm_funcs mbedtls_ccm_vanilla_mbedtls_backend_funcs = {
+    .backend_context_size = (4 * VANILLA_MBEDTLS_CCM_CONTEXT_WORDS),
     .check = mbedtls_ccm_check,
     .init = mbedtls_ccm_init,
     .setkey = mbedtls_ccm_setkey,

--- a/nrf_security/src/mbedcrypto_glue/vanilla/cmac_vanilla.c
+++ b/nrf_security/src/mbedcrypto_glue/vanilla/cmac_vanilla.c
@@ -34,7 +34,7 @@ static void mbedtls_cipher_cmac_free(mbedtls_cipher_context_t *ctx)
     }
 }
 
-const mbedtls_cmac_funcs mbedtls_cmac_default_backend_funcs = {
+const mbedtls_cmac_funcs mbedtls_cmac_vanilla_mbedtls_backend_funcs = {
     .check = mbedtls_cipher_cmac_check,
     .starts = mbedtls_cipher_cmac_starts,
     .update = mbedtls_cipher_cmac_update,

--- a/nrf_security/src/mbedcrypto_glue/vanilla/dhm_vanilla.c
+++ b/nrf_security/src/mbedcrypto_glue/vanilla/dhm_vanilla.c
@@ -17,7 +17,7 @@ static int mbedtls_dhm_check(unsigned int pbits)
     return 1;
 }
 
-const mbedtls_dhm_funcs mbedtls_dhm_default_backend_funcs = {
+const mbedtls_dhm_funcs mbedtls_dhm_vanilla_mbedtls_backend_funcs = {
     .check = mbedtls_dhm_check,
     .init = mbedtls_dhm_init,
     .read_params = mbedtls_dhm_read_params,

--- a/nrf_security/src/mbedcrypto_glue/vanilla/ecdh_vanilla.c
+++ b/nrf_security/src/mbedcrypto_glue/vanilla/ecdh_vanilla.c
@@ -17,7 +17,7 @@ static int mbedtls_ecdh_check(mbedtls_ecp_group *grp, int function)
     return 1;
 }
 
-const mbedtls_ecdh_funcs mbedtls_ecdh_default_backend_funcs = {
+const mbedtls_ecdh_funcs mbedtls_ecdh_vanilla_mbedtls_backend_funcs = {
     .check = mbedtls_ecdh_check,
     .gen_public = mbedtls_ecdh_gen_public,
     .compute_shared = mbedtls_ecdh_compute_shared,

--- a/nrf_security/src/mbedcrypto_glue/vanilla/ecdsa_vanilla.c
+++ b/nrf_security/src/mbedcrypto_glue/vanilla/ecdsa_vanilla.c
@@ -17,7 +17,7 @@ static int mbedtls_ecdsa_check(mbedtls_ecp_group *grp, mbedtls_ecp_group_id gid,
     return 1;
 }
 
-const mbedtls_ecdsa_funcs mbedtls_ecdsa_default_backend_funcs = {
+const mbedtls_ecdsa_funcs mbedtls_ecdsa_vanilla_mbedtls_backend_funcs = {
     .check = mbedtls_ecdsa_check,
     .sign = mbedtls_ecdsa_sign,
     .verify = mbedtls_ecdsa_verify,

--- a/nrf_security/src/mbedcrypto_glue/vanilla/rsa_vanilla.c
+++ b/nrf_security/src/mbedcrypto_glue/vanilla/rsa_vanilla.c
@@ -6,13 +6,13 @@
 
 #if defined(MBEDTLS_BACKEND_RSA_DEFAULT) && defined(MBEDTLS_BACKEND_RSA_GLUE)
 
-#include <assert.h>
+#include <toolchain.h>
 
 #include "mbedtls/rsa.h"
 #include "backend_rsa.h"
 
 
-static_assert(MBEDTLS_DEFAULT_RSA_CONTEXT_WORDS  == (sizeof(mbedtls_rsa_context) + 3) / 4, "Invalid MBEDTLS_DEFAULT_RSA_CONTEXT_WORDS value");
+BUILD_ASSERT_MSG(VANILLA_MBEDTLS_RSA_CONTEXT_WORDS  == (sizeof(mbedtls_rsa_context) + 3) / 4, "Invalid VANILLA_MBEDTLS_RSA_CONTEXT_WORDS value");
 
 
 static int mbedtls_rsa_check(int padding, int hash_id, unsigned int nbits)
@@ -20,8 +20,8 @@ static int mbedtls_rsa_check(int padding, int hash_id, unsigned int nbits)
     return 1;
 }
 
-const mbedtls_rsa_funcs mbedtls_rsa_default_backend_funcs = {
-    .backend_context_size = (4 * MBEDTLS_DEFAULT_RSA_CONTEXT_WORDS),
+const mbedtls_rsa_funcs mbedtls_rsa_vanilla_mbedtls_backend_funcs = {
+    .backend_context_size = (4 * VANILLA_MBEDTLS_RSA_CONTEXT_WORDS),
     .check = mbedtls_rsa_check,
     .init = mbedtls_rsa_init,
     .import = mbedtls_rsa_import,

--- a/nrf_security/src/mbedtls/CMakeLists.txt
+++ b/nrf_security/src/mbedtls/CMakeLists.txt
@@ -152,6 +152,7 @@ zephyr_library_sources(${src_tls} ${src_tls_replacement} ${MBEDTLS_CONFIGURATION
 zephyr_library_include_directories(${common_includes})
 zephyr_library_compile_definitions(-DMBEDTLS_CONFIG_FILE=${MBEDTLS_CONFIGURATION})
 zephyr_library_link_libraries(zephyr_interface)
+target_link_libraries(mbedtls_vanilla INTERFACE mbedx509_vanilla)
 if(TARGET mbedcrypto_cc310)
   zephyr_library_include_directories(
     $<TARGET_PROPERTY:mbedcrypto_cc310,INTERFACE_INCLUDE_DIRECTORIES>


### PR DESCRIPTION
To ensure the mbedtls_cipher_* functions from cipher.c is no longer
renamed as those only exists in vanilla mbedTLS.
    
mbedtls_platform_zeroize will not be renamed for the cc310 if multiple
backends are selected, while other backends will still have their
symbol renamed.

also ensuring correct link ordering and dependencies when linking to
mbedtls then mbedtls is now linked with mbedx509.

Fixed naming of defines and functions in glue layer as there were
mismatch in naming.

Adjust backend libraries to be Zephyr libraries to ensure autoconf.h is
included during compilation.    
