### PR TITLE
cmake: added ${IMAGE} on all target handling to support multi image

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -51,13 +51,13 @@ if (CONFIG_CC310_BACKEND)
     message(WARNING "This combination of SoC, floating point ABI, and interrupts settings is not supported by the nrf_cc310_mbedcryto lib."
                     "(${NRF_CC310_LIB} doesn't exist.)")
   endif()
-  add_library(mbedcrypto_cc310 STATIC IMPORTED GLOBAL)
-  set_target_properties(mbedcrypto_cc310 PROPERTIES IMPORTED_LOCATION
+  add_library(${IMAGE}mbedcrypto_cc310 STATIC IMPORTED GLOBAL)
+  set_target_properties(${IMAGE}mbedcrypto_cc310 PROPERTIES IMPORTED_LOCATION
                         "${NRF_CC310_LIB}"
   )
-  target_include_directories(mbedcrypto_cc310 INTERFACE 
+  target_include_directories(${IMAGE}mbedcrypto_cc310 INTERFACE
                              "${NRF_CC310_BASE}/include/mbedtls")
-  target_link_libraries(mbedcrypto_cc310 INTERFACE mbedcrypto_vanilla)
+  target_link_libraries(${IMAGE}mbedcrypto_cc310 INTERFACE ${IMAGE}mbedcrypto_vanilla)
   if (NOT CONFIG_NRF_CRYPTO_BACKEND_COMBINATION_0)
     # Only CC310 backend is selected for mbedtls API.
     # Thus export the alt headers through Zephyr interface library.

--- a/nrf_security/cmake/symbol_rename.cmake
+++ b/nrf_security/cmake/symbol_rename.cmake
@@ -48,27 +48,27 @@ function(library_redefine_symbols backend template)
   configure_file(${template}
                  symbol_rename_${MBEDTLS_BACKEND_PREFIX}.txt)
   
-  set(BACKEND_RENAMED_LIBARY libmbedcrypto_${MBEDTLS_BACKEND_PREFIX}_backend.a)
+  set(BACKEND_RENAMED_LIBARY lib${IMAGE}mbedcrypto_${MBEDTLS_BACKEND_PREFIX}_backend.a)
   add_custom_command(
     OUTPUT ${BACKEND_RENAMED_LIBARY}
     COMMAND ${CMAKE_OBJCOPY} 
             --redefine-syms
             ${CMAKE_CURRENT_BINARY_DIR}/symbol_rename_${MBEDTLS_BACKEND_PREFIX}.txt
-            $<TARGET_FILE:mbedcrypto_${MBEDTLS_BACKEND_PREFIX}>
+            $<TARGET_FILE:${IMAGE}mbedcrypto_${MBEDTLS_BACKEND_PREFIX}>
             ${BACKEND_RENAMED_LIBARY}
-    DEPENDS mbedcrypto_${MBEDTLS_BACKEND_PREFIX}
+    DEPENDS ${IMAGE}mbedcrypto_${MBEDTLS_BACKEND_PREFIX}
             ${CMAKE_CURRENT_BINARY_DIR}/symbol_rename_${MBEDTLS_BACKEND_PREFIX}.txt
   )
-  add_custom_target(${MBEDTLS_BACKEND_PREFIX}_backend_target
+  add_custom_target(${IMAGE}${MBEDTLS_BACKEND_PREFIX}_backend_target
                     DEPENDS ${BACKEND_RENAMED_LIBARY}
   )
-  add_library(mbedcrypto_${MBEDTLS_BACKEND_PREFIX}_backend STATIC IMPORTED GLOBAL)
-  add_dependencies(mbedcrypto_${MBEDTLS_BACKEND_PREFIX}_backend
-                   ${MBEDTLS_BACKEND_PREFIX}_backend_target)
-  set_target_properties(mbedcrypto_${MBEDTLS_BACKEND_PREFIX}_backend
+  add_library(${IMAGE}mbedcrypto_${MBEDTLS_BACKEND_PREFIX}_backend STATIC IMPORTED GLOBAL)
+  add_dependencies(${IMAGE}mbedcrypto_${MBEDTLS_BACKEND_PREFIX}_backend
+                   ${IMAGE}${MBEDTLS_BACKEND_PREFIX}_backend_target)
+  set_target_properties(${IMAGE}mbedcrypto_${MBEDTLS_BACKEND_PREFIX}_backend
                         PROPERTIES IMPORTED_LOCATION
                         "${CMAKE_CURRENT_BINARY_DIR}/${BACKEND_RENAMED_LIBARY}")
 
-  zephyr_append_cmake_library(mbedcrypto_${MBEDTLS_BACKEND_PREFIX}_backend)
+  zephyr_append_cmake_library(${IMAGE}mbedcrypto_${MBEDTLS_BACKEND_PREFIX}_backend)
 endfunction()
 

--- a/nrf_security/src/mbedcrypto_glue/CMakeLists.txt
+++ b/nrf_security/src/mbedcrypto_glue/CMakeLists.txt
@@ -40,7 +40,7 @@ if(CONFIG_GLUE_MBEDTLS_AES_C)
   include(${CMAKE_CURRENT_LIST_DIR}/cc310/CMakeLists.txt)
   include(${CMAKE_CURRENT_LIST_DIR}/vanilla/CMakeLists.txt)
 else()
-  add_library(mbedcrypto_glue INTERFACE)
+  add_library(${IMAGE}mbedcrypto_glue INTERFACE)
 endif()
 
 # Platform implementation cannot be chosen Kconfig.

--- a/nrf_security/src/mbedcrypto_glue/cc310/CMakeLists.txt
+++ b/nrf_security/src/mbedcrypto_glue/cc310/CMakeLists.txt
@@ -16,14 +16,14 @@ if(CONFIG_CC310_BACKEND)
   )
   zephyr_library_compile_definitions(MBEDTLS_BACKEND_PREFIX=cc310)
 
-  zephyr_library_include_directories($<TARGET_PROPERTY:mbedcrypto_glue,INCLUDE_DIRECTORIES>)
-  zephyr_library_compile_definitions($<TARGET_PROPERTY:mbedcrypto_glue,COMPILE_DEFINITIONS>)
+  zephyr_library_include_directories($<TARGET_PROPERTY:${IMAGE}mbedcrypto_glue,INCLUDE_DIRECTORIES>)
+  zephyr_library_compile_definitions($<TARGET_PROPERTY:${IMAGE}mbedcrypto_glue,COMPILE_DEFINITIONS>)
   add_custom_command(
-    TARGET mbedcrypto_glue_cc310
+    TARGET ${IMAGE}mbedcrypto_glue_cc310
     POST_BUILD
     COMMAND ${CMAKE_OBJCOPY} 
             --redefine-syms
             ${CMAKE_CURRENT_BINARY_DIR}/symbol_rename_cc310.txt
-            $<TARGET_FILE:mbedcrypto_glue_cc310>
+            $<TARGET_FILE:${IMAGE}mbedcrypto_glue_cc310>
   )
 endif()

--- a/nrf_security/src/mbedcrypto_glue/vanilla/CMakeLists.txt
+++ b/nrf_security/src/mbedcrypto_glue/vanilla/CMakeLists.txt
@@ -16,14 +16,14 @@ if (CONFIG_MBEDTLS_VANILLA_BACKEND)
   
   zephyr_library_compile_definitions(MBEDTLS_BACKEND_PREFIX=vanilla)
 
-  zephyr_library_include_directories($<TARGET_PROPERTY:mbedcrypto_glue,INCLUDE_DIRECTORIES>)
-  zephyr_library_compile_definitions($<TARGET_PROPERTY:mbedcrypto_glue,COMPILE_DEFINITIONS>)
+  zephyr_library_include_directories($<TARGET_PROPERTY:${IMAGE}mbedcrypto_glue,INCLUDE_DIRECTORIES>)
+  zephyr_library_compile_definitions($<TARGET_PROPERTY:${IMAGE}mbedcrypto_glue,COMPILE_DEFINITIONS>)
   add_custom_command(
-    TARGET mbedcrypto_glue_vanilla
+    TARGET ${IMAGE}mbedcrypto_glue_vanilla
     POST_BUILD
     COMMAND ${CMAKE_OBJCOPY} 
             --redefine-syms
             ${CMAKE_CURRENT_BINARY_DIR}/symbol_rename_vanilla.txt
-            $<TARGET_FILE:mbedcrypto_glue_vanilla>
+            $<TARGET_FILE:${IMAGE}mbedcrypto_glue_vanilla>
   )
 endif()

--- a/nrf_security/src/mbedtls/CMakeLists.txt
+++ b/nrf_security/src/mbedtls/CMakeLists.txt
@@ -121,44 +121,56 @@ PREPEND(src_tls_replacement ${NRF_MBEDTLS_ROOT}/src/mbedtls/replacements/
 zephyr_include_directories(${ARM_MBEDTLS_ROOT}/include)
 zephyr_include_directories(${ARM_MBEDTLS_ROOT}/include/mbedtls)
 
-add_library(mbedcrypto_vanilla STATIC "")
-set(ZEPHYR_CURRENT_LIBRARY mbedcrypto_vanilla)
+# When using multiple backends this library should not be linked directly as
+# there might be name collisions with other libs, e.g. mbedcrypto_cc310
+# When multiple backends are enabled, unique symbols are guaranteed through
+# symbol renaming and glue layer.
+# Therefore add_library is used instead of zephyr_library
+add_library(${IMAGE}mbedcrypto_vanilla STATIC "")
+set(ZEPHYR_CURRENT_LIBRARY ${IMAGE}mbedcrypto_vanilla)
 zephyr_library_sources(${src_crypto} ${src_crypto_replacement})
 zephyr_library_include_directories(${common_includes})
-zephyr_library_link_libraries(zephyr_interface)
+zephyr_library_link_libraries(${IMAGE}zephyr_interface)
 zephyr_library_compile_definitions_ifdef(CONFIG_MBEDTLS_CIPHER_AES_256_ECB_C MBEDTLS_CIPHER_AES_256_ECB_C)
 zephyr_library_compile_definitions_ifdef(CONFIG_MBEDTLS_CIPHER_AES_256_CBC_C MBEDTLS_CIPHER_AES_256_CBC_C)
 zephyr_library_compile_definitions_ifdef(CONFIG_MBEDTLS_CIPHER_AES_256_CTR_C MBEDTLS_CIPHER_AES_256_CTR_C)
 zephyr_library_compile_definitions_ifdef(CONFIG_MBEDTLS_CIPHER_AES_256_CCM_C MBEDTLS_CIPHER_AES_256_CCM_C)
-if(TARGET mbedcrypto_cc310)
-  target_link_libraries(mbedcrypto_vanilla PRIVATE mbedcrypto_cc310)
+if(TARGET ${IMAGE}mbedcrypto_cc310)
+  target_link_libraries(${IMAGE}mbedcrypto_vanilla PRIVATE ${IMAGE}mbedcrypto_cc310)
 endif()
 
-add_library(mbedx509_vanilla STATIC "")
-set(ZEPHYR_CURRENT_LIBRARY mbedx509_vanilla)
+# The mbedx509 library is currently provided for evaluation only, and when used
+# it should be linked directly with the app using CMake.
+# Therefore zephyr_library is not used.
+add_library(${IMAGE}mbedx509_vanilla STATIC "")
+set(ZEPHYR_CURRENT_LIBRARY ${IMAGE}mbedx509_vanilla)
 zephyr_library_sources(${src_x509})
 zephyr_library_include_directories(${common_includes})
 zephyr_library_compile_definitions(-DMBEDTLS_CONFIG_FILE=${MBEDTLS_CONFIGURATION})
-zephyr_library_link_libraries(zephyr_interface)
-if(TARGET mbedcrypto_cc310)
+zephyr_library_link_libraries(${IMAGE}zephyr_interface)
+if(TARGET ${IMAGE}mbedcrypto_cc310)
   zephyr_library_include_directories(
-    $<TARGET_PROPERTY:mbedcrypto_cc310,INTERFACE_INCLUDE_DIRECTORIES>
+    $<TARGET_PROPERTY:${IMAGE}mbedcrypto_cc310,INTERFACE_INCLUDE_DIRECTORIES>
   )
 endif()
 
-add_library(mbedtls_vanilla STATIC "")
-set(ZEPHYR_CURRENT_LIBRARY mbedtls_vanilla)
+# The mbedtls library is currently provided for evaluation only, and when used
+# it should be linked directly with the app using CMake.
+# Therefore zephyr_library is not used.
+add_library(${IMAGE}mbedtls_vanilla STATIC "")
+set(ZEPHYR_CURRENT_LIBRARY ${IMAGE}mbedtls_vanilla)
 zephyr_library_sources(${src_tls} ${src_tls_replacement} ${MBEDTLS_CONFIGURATION_FILE})
 zephyr_library_include_directories(${common_includes})
 zephyr_library_compile_definitions(-DMBEDTLS_CONFIG_FILE=${MBEDTLS_CONFIGURATION})
-zephyr_library_link_libraries(zephyr_interface)
-target_link_libraries(mbedtls_vanilla INTERFACE mbedx509_vanilla)
-if(TARGET mbedcrypto_cc310)
+zephyr_library_link_libraries(${IMAGE}zephyr_interface)
+target_link_libraries(${IMAGE}mbedtls_vanilla INTERFACE ${IMAGE}mbedx509_vanilla)
+if(TARGET ${IMAGE}mbedcrypto_cc310)
   zephyr_library_include_directories(
-    $<TARGET_PROPERTY:mbedcrypto_cc310,INTERFACE_INCLUDE_DIRECTORIES>
+    $<TARGET_PROPERTY:${IMAGE}mbedcrypto_cc310,INTERFACE_INCLUDE_DIRECTORIES>
   )
 endif()
 
 if(NOT CONFIG_NRF_CRYPTO_BACKEND_COMBINATION_0)
-  zephyr_append_cmake_library(mbedcrypto_vanilla)
+  # Only vanilla backend is chosen, thus append it to zephyr libraries.
+  zephyr_append_cmake_library(${IMAGE}mbedcrypto_vanilla)
 endif()


### PR DESCRIPTION
To support nrf security in SPM the CMake files controlling the
crypto and mbedtls libraries no have all target references prefixed
with ${PREFIX}.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>