### PR TITLE
nfc: Update deprecated device tree symbols

### DIFF
--- a/nfc/src/nfc_platform_zephyr.c
+++ b/nfc/src/nfc_platform_zephyr.c
@@ -20,7 +20,7 @@ nrfx_err_t nfc_platform_setup(void)
 {
 	int err;
 
-	clock = device_get_binding(DT_NORDIC_NRF_CLOCK_0_LABEL "_16M");
+	clock = device_get_binding(DT_INST_0_NORDIC_NRF_CLOCK_LABEL "_16M");
 	__ASSERT_NO_MSG(clock);
 
 	err = clock_control_on(clock, (void *)1);


### PR DESCRIPTION
With recent DT changes in Zephyr upstream, some DT symbols became
obsolete, which causes warnings during compilation.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>