### PR TITLE
crypto: cc310_bl: Reword prompt

### DIFF
--- a/crypto/Kconfig
+++ b/crypto/Kconfig
@@ -10,7 +10,7 @@ config NRF_OBERON
 	  To use, link with nrfxlib_crypto in CMake.
 
 config NRF_CC310_BL
-	bool "nrf_cc310_bl HW crypto library for nRF52840."
+	bool "nrf_cc310_bl HW crypto library for nRF devices with CryptoCell CC310."
 	select NRFXLIB_CRYPTO
 	select FLOAT # The cc310_bl lib uses floating point registers.
 	help


### PR DESCRIPTION
Not only nRF52840 has CC310.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>