### PR TITLE
NCSDK-2480: Add Nordics 5-clause license to bsdlib.

### DIFF
--- a/bsdlib/license.txt
+++ b/bsdlib/license.txt
@@ -1,0 +1,5 @@
+/*
+ * Copyright (c) 2017 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */


### PR DESCRIPTION
Add Nordics 5-clause license to bsdlib.

Signed-off-by: Rune Holmgren <Raane.Holm@gmail.com>