### PR TITLE
nfc: add license

### DIFF
--- a/nfc/license.txt
+++ b/nfc/license.txt
@@ -1,0 +1,5 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */


### PR DESCRIPTION
Adding license reference for NFC libraries.

Signed-off-by: Michał Grochala <michal.grochala@nordicsemi.no>