### PR TITLE
ci: use Standard Library in Jenkinsfile to link sub-projects together

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,158 @@
+
+@Library("CI_LIB") _
+
+def AGENT_LABELS = lib_Main.getAgentLabels(JOB_NAME)
+def IMAGE_TAG    = lib_Main.getDockerImage(JOB_NAME)
+def TIMEOUT      = lib_Main.getTimeout(JOB_NAME)
+def INPUT_STATE  = lib_Main.getInputState(JOB_NAME)
+def CI_STATE = new HashMap()
+
+pipeline {
+
+  parameters {
+       booleanParam(name: 'RUN_DOWNSTREAM', description: 'if false skip downstream jobs', defaultValue: true)
+       booleanParam(name: 'RUN_TESTS', description: 'if false skip testing', defaultValue: true)
+       booleanParam(name: 'RUN_BUILD', description: 'if false skip building', defaultValue: true)
+       string(name: 'jsonstr_CI_STATE', description: 'Default State if no upstream job',
+              defaultValue: INPUT_STATE)
+  }
+
+  agent {
+    docker {
+      image IMAGE_TAG
+      label AGENT_LABELS
+      args '-e PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/workdir/.local/bin'
+    }
+  }
+
+  options {
+    checkoutToSubdirectory('nrfxlib')
+    timeout(time: TIMEOUT.time, unit: TIMEOUT.unit)
+  }
+
+  triggers {
+    cron(env.BRANCH_NAME == 'master' ? '0 */4 * * 1-7' : '') // Only master will be build periodically
+  }
+
+  environment {
+      // ENVs for check-compliance
+      GH_TOKEN = credentials('nordicbuilder-compliance-token') // This token is used to by check_compliance to comment on PRs and use checks
+      GH_USERNAME = "NordicBuilder"
+      COMPLIANCE_ARGS = "-r NordicPlayground/nrfxlib"
+
+      // Build all custom samples that match the ci_build tag
+      SANITYCHECK_OPTIONS = "--board-root $WORKSPACE/nrf/boards --testcase-root $WORKSPACE/nrf/samples --testcase-root $WORKSPACE/nrf/applications --build-only --disable-unrecognized-section-test -t ci_build --inline-logs"
+      ARCH = "-a arm"
+      LC_ALL = "C.UTF-8"
+
+      // ENVs for building (triggered by sanitycheck)
+      ZEPHYR_TOOLCHAIN_VARIANT = 'gnuarmemb'
+      GNUARMEMB_TOOLCHAIN_PATH = '/workdir/gcc-arm-none-eabi-7-2018-q2-update'
+  }
+
+  stages {
+    stage('Load') { steps { script { CI_STATE = lib_Stage.load('NRFXLIB') }}}
+    stage('Checkout') {
+      steps { script {
+        lib_Main.cloneCItools(JOB_NAME)
+        dir('nrfxlib') {
+          CI_STATE.NRFXLIB.REPORT_SHA = lib_Main.checkoutRepo(CI_STATE.NRFXLIB.GIT_URL, "NRFXLIB", CI_STATE.NRFXLIB, false)
+          lib_West.AddManifestUpdate("NRFXLIB", 'nrfxlib', CI_STATE.NRFXLIB.GIT_URL, CI_STATE.NRFXLIB.GIT_REF, CI_STATE)
+        }
+      }}
+    }
+    stage('Get manifest && Apply Parent Manifest Updates') {
+      when { expression { CI_STATE.NRFXLIB.RUN_TESTS || CI_STATE.NRFXLIB.RUN_BUILD } }
+      steps { script {
+        lib_Status.set('PENDING', 'NRFXLIB', CI_STATE)
+        // lib_West.InitUpdate('nrfxlib')
+        lib_West.ApplyManifestUpdates(CI_STATE)
+      }}
+    }
+    stage('Run compliance check') {
+      when { expression { CI_STATE.NRFXLIB.RUN_TESTS } }
+      steps {
+        dir('nrfxlib') {
+          script {
+            // If we're a pull request, compare the target branch against the current HEAD (the PR), and also report issues to the PR
+            def BUILD_TYPE = lib_Main.getBuildType(CI_STATE.NRFXLIB)
+            if (BUILD_TYPE == "PR") {
+              COMMIT_RANGE = "$CI_STATE.NRFXLIB.MERGE_BASE..$CI_STATE.NRFXLIB.REPORT_SHA"
+              COMPLIANCE_ARGS = "$COMPLIANCE_ARGS -p $CHANGE_ID -S $CI_STATE.NRFXLIB.REPORT_SHA -g"
+              println "Building a PR [$CHANGE_ID]: $COMMIT_RANGE"
+            }
+            else if (BUILD_TYPE == "TAG") {
+              COMMIT_RANGE = "tags/${env.BRANCH_NAME}..tags/${env.BRANCH_NAME}"
+              println "Building a Tag: " + COMMIT_RANGE
+            }
+            // If not a PR, it's a non-PR-branch or master build. Compare against the origin.
+            else if (BUILD_TYPE == "BRANCH") {
+              COMMIT_RANGE = "origin/${env.BRANCH_NAME}..HEAD"
+              println "Building a Branch: " + COMMIT_RANGE
+            }
+            else {
+                assert condition : "Build fails because it is not a PR/Tag/Branch"
+            }
+
+            // Run the compliance check
+            try {
+              sh "../ci-tools/scripts/check_compliance.py $COMPLIANCE_ARGS --commits $COMMIT_RANGE"
+            }
+            finally {
+              junit 'compliance.xml'
+              archiveArtifacts artifacts: 'compliance.xml'
+            }
+          }
+        }
+      }
+    }
+    stage('Build samples') {
+      when { expression { CI_STATE.NRFXLIB.RUN_BUILD } }
+      steps {
+          echo "No Samples to build yet."
+      }
+    }
+    stage('Trigger testing build') {
+      when { expression { CI_STATE.NRFXLIB.RUN_DOWNSTREAM } }
+      steps {
+        script {
+          CI_STATE.NRFXLIB.WAITING = true
+          def DOWNSTREAM_JOBS = lib_Main.getDownStreamJobs(JOB_NAME)
+          def jobs = [:]
+          DOWNSTREAM_JOBS.each {
+            jobs["${it}"] = {
+              build job: "${it}", propagate: true, wait: true, parameters: [
+                        string(name: 'jsonstr_CI_STATE', value: lib_Util.HashMap2Str(CI_STATE))]
+            }
+          }
+          parallel jobs
+        }
+      }
+    }
+  }
+  post {
+    // This is the order that the methods are run. {always->success/abort/failure/unstable->cleanup}
+    always {
+      echo "always"
+    }
+    success {
+      echo "success"
+      script { lib_Status.set("SUCCESS", 'NRFXLIB', CI_STATE) }
+    }
+    aborted {
+      echo "aborted"
+      script { lib_Status.set("ABORTED", 'NRFXLIB', CI_STATE) }
+    }
+    unstable {
+      echo "unstable"
+    }
+    failure {
+      echo "failure"
+      script { lib_Status.set("FAILURE", 'NRFXLIB', CI_STATE) }
+    }
+    cleanup {
+        echo "cleanup"
+        cleanWs()
+    }
+  }
+}


### PR DESCRIPTION
Managing Docker version, Agent Labels, Github Status, manifest updates, downstream jobs from CI_LIB.

More info: https://projecttools.nordicsemi.no/confluence/display/NCS/Linking+Jenkins+Jobs+Together

Signed-off-by: Thomas Stilwell Thomas.Stilwell@nordicsemi.no