### PR TITLE
Add Kconfig option CONFIG_SHORT_WCHAR_T

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -10,20 +10,29 @@ if(__NRFXLIB_COMMON_CMAKE__)
 endif()
 set(__NRFXLIB_COMMON_CMAKE__ TRUE)
 
+#
+# Build the path of the library taking in
+# -Arch type
+# -Float ABI
+# -wchar_t size
+#
 function(nrfxlib_calculate_lib_path lib_path)
-  if(CONFIG_FLOAT)
-	if(CONFIG_FP_HARDABI)
-      set(float_dir hard-float)
-	elseif(CONFIG_FP_SOFTABI)
-      set(float_dir softfp-float)
-	else()
-      assert(0 "Unreachable code")
-	endif()
-  else()
-	set(float_dir soft-float)
-  endif()
-
+  # Add Arch type
   assert(GCC_M_CPU "GCC_M_CPU must be set to find correct lib.")
-
-  set(${lib_path} lib/${GCC_M_CPU}/${float_dir} PARENT_SCOPE)
+  # Set floating ABI
+  if(CONFIG_FLOAT)
+    if(CONFIG_FP_HARDABI)
+        set(float_dir hard-float)
+    elseif(CONFIG_FP_SOFTABI)
+        set(float_dir softfp-float)
+    else()
+        assert(0 "Unreachable code")
+    endif()
+  else()
+	  set(float_dir soft-float)
+  endif()
+  if (CONFIG_SHORT_WCHAR_T)
+    set(short_wchar "/short-wchar")
+  endif()
+  set(${lib_path} "lib/${GCC_M_CPU}/${float_dir}${short_wchar}" PARENT_SCOPE)
 endfunction()

--- a/crypto/Kconfig
+++ b/crypto/Kconfig
@@ -3,6 +3,12 @@ menu "Crypto libraries for nRF5x SOCs."
 config NRFXLIB_CRYPTO
 	bool
 
+config SHORT_WCHAR_T
+	bool "Compile with short wchar_t size (2 bytes)"
+	help
+		This compiles zephyr and libraries with -fshort-wchar
+		Don't set this define if libgcc is in use
+
 config NRF_OBERON
 	bool "nrf_oberon SW crypto library for nRF5x."
 	select NRFXLIB_CRYPTO


### PR DESCRIPTION
-Added Kconfig option to indicate build with -fshort-wchar
-Updated nrfxlib_caculate_lib_path to also select short-wchar

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>