### PR TITLE
nfc: Fix default IRQ priority when ZERO_LATENCY_IRQS are used

### DIFF
--- a/nfc/Kconfig
+++ b/nfc/Kconfig
@@ -27,10 +27,11 @@ config NFCT_IRQ_PRIORITY
 	int
 	prompt "Interrupt priority"
 	range 0 6
+	default 5 if ZERO_LATENCY_IRQS
 	default 6
 	help
 		Sets NFC interrupt priority.
-		Levels are from 0 (highest priority) to 7 (lowest priority)
+		Levels are from 0 (highest priority) to 6 (lowest priority)
 
 choice
 	prompt "NFC platform logging level"


### PR DESCRIPTION
Fixes NCSDK-3404 and a small documentation bug.

Signed-off-by: Thomas Stenersen <thomas.stenersen@nordicsemi.no>