### PR TITLE
nrf_security: introduces mbedtls heap in nrf_security

### DIFF
--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -47,6 +47,30 @@ config MBEDTLS_TLS_LIBRARY
 	  Create the mbed SSL/TLS library in addition to the mbed crypto
 	  library.
 
+menu "mbed TLS memory configuration"
+
+config MBEDTLS_ENABLE_HEAP
+	bool "Enable global heap for mbed TLS"
+	help
+	  This option enables the mbedtls to use the heap. This setting must
+	  be global so that various applications and libraries in Zephyr do not
+	  try to do this themselves as there can be only one heap defined
+	  in mbedtls. If this is enabled, then the Zephyr will, during the device
+	  startup, initialize the heap automatically.
+
+config MBEDTLS_HEAP_SIZE
+	int "Heap size for mbed TLS"
+	default 512
+	depends on MBEDTLS_ENABLE_HEAP
+	help
+	  The mbedtls routines will use this heap if enabled.
+	  For streaming communication with arbitrary (HTTPS) servers on the
+	  Internet, 32KB + overheads (up to another 20KB) may be needed.
+	  Ensure to adjust the heap size according to the need of the
+	  application.
+
+endmenu
+
 comment "Backend Selection"
 
 config CC310_BACKEND

--- a/nrf_security/src/mbedtls/CMakeLists.txt
+++ b/nrf_security/src/mbedtls/CMakeLists.txt
@@ -181,7 +181,8 @@ zephyr_library_sources_ifdef(VANILLA_ONLY_MBEDTLS_POLY1305_C
 zephyr_library_sources_ifdef(VANILLA_ONLY_MBEDTLS_CHACHAPOLY_C
   ${ARM_MBEDTLS_PATH}/library/chachapoly.c
 )
-zephyr_library_sources(${ZEPHYR_BASE}/../modules/crypto/mbedtls/zephyr_init.c)
+zephyr_library_sources_ifdef(CONFIG_MBEDTLS_ENABLE_HEAP ${NRF_SECURITY_ROOT}/src/mbedtls/mbedtls_heap.c)
+zephyr_library_app_memory(k_mbedtls_partition)
 
 if(CONFIG_SOC_NRF52840 OR CONFIG_SOC_NRF9160)
   zephyr_library_sources(${NRF_SECURITY_ROOT}/src/backend/cc310/replacements/entropy.c)
@@ -199,6 +200,7 @@ if (CONFIG_MBEDTLS_X509_LIBRARY)
   zephyr_library_sources(${src_x509})
   zephyr_library_link_libraries(${IMAGE}mbedtls_common)
   nrf_security_debug_list_target_files(${IMAGE}mbedtls_x509_vanilla)
+  zephyr_library_app_memory(k_mbedtls_partition)
 endif()
 
 #
@@ -209,6 +211,7 @@ if (CONFIG_MBEDTLS_TLS_LIBRARY)
   zephyr_library_sources(${src_tls} ${src_tls_replacement})
   zephyr_library_link_libraries(${IMAGE}mbedtls_common)
   nrf_security_debug_list_target_files(${IMAGE}mbedtls_tls_vanilla)
+  zephyr_library_app_memory(k_mbedtls_partition)
 endif()
 
 if(NOT CONFIG_NRF_CRYPTO_BACKEND_COMBINATION_0)

--- a/nrf_security/src/mbedtls/mbedtls_heap.c
+++ b/nrf_security/src/mbedtls/mbedtls_heap.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <init.h>
+#include <app_memory/app_memdomain.h>
+
+#include "mbedtls/memory_buffer_alloc.h"
+
+#if !defined(CONFIG_MBEDTLS_HEAP_SIZE) || CONFIG_MBEDTLS_HEAP_SIZE == 0
+#error "CONFIG_MBEDTLS_HEAP_SIZE must be specified and greater than 0"
+#endif
+
+static unsigned char mbedtls_heap[CONFIG_MBEDTLS_HEAP_SIZE];
+
+static int mbedtls_heap_init(struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	mbedtls_memory_buffer_alloc_init(mbedtls_heap, sizeof(mbedtls_heap));
+
+	return 0;
+}
+
+/* Hw cc310 is initialized with CONFIG_KERNEL_INIT_PRIORITY_DEFAULT and the
+ * heap must be initialized afterwards.
+ */
+SYS_INIT(mbedtls_heap_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);


### PR DESCRIPTION
This commit introduces mbedtls_heap.c in nrf security and also add
globals in compiled libraries to userspace config using
zephyr_library_app_memory.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>