### PR TITLE
nfc: Limit NFCT_IRQ_PRIORITY range if ZERO_LATENCY_IRQS is enabled

### DIFF
--- a/nfc/Kconfig
+++ b/nfc/Kconfig
@@ -26,6 +26,7 @@ config NFC_T4T_LIB_ENABLED
 config NFCT_IRQ_PRIORITY
 	int
 	prompt "Interrupt priority"
+	range 0 5 if ZERO_LATENCY_IRQS
 	range 0 6
 	default 5 if ZERO_LATENCY_IRQS
 	default 6


### PR DESCRIPTION
This fixes a problem where the NFCT_IRQ_PRIORITY is stuck at 6 if
ZERO_LATENCY_IRQS are enabled after the initial configuration of the
project.

@SebastianBoe 

FYI: @kapi-no 