### PR TITLE
cmake: Adopted to new multi image approach

### DIFF
--- a/bsdlib/CMakeLists.txt
+++ b/bsdlib/CMakeLists.txt
@@ -19,8 +19,8 @@ endif()
 # lib oberon are linked in because they are used by the bsd library
 # and must therefore be placed after the bsd library on the linker's
 # command line.
-set(                    BSDLIB_TARGET             ${IMAGE}bsd_nrf9160_xxaa)
+set(                    BSDLIB_TARGET             bsd_nrf9160_xxaa)
 zephyr_library_import(${BSDLIB_TARGET} ${BSD_LIB_PATH}/libbsd_nrf9160_xxaa.a)
-target_link_libraries(${BSDLIB_TARGET} INTERFACE ${IMAGE}nrfxlib_crypto -lc)
+target_link_libraries(${BSDLIB_TARGET} INTERFACE nrfxlib_crypto -lc)
 
 zephyr_include_directories(include)

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -18,8 +18,8 @@ if (CONFIG_NRF_OBERON)
     message(WARNING "This combination of SoC and floating point ABI is not supported by the nrf_oberon lib."
                     "(${OBERON_LIB} doesn't exist.)")
   endif()
-  target_include_directories(${IMAGE}nrfxlib_crypto INTERFACE ${OBERON_BASE}/include)
-  target_link_libraries(${IMAGE}nrfxlib_crypto INTERFACE ${OBERON_LIB})
+  target_include_directories(nrfxlib_crypto INTERFACE ${OBERON_BASE}/include)
+  target_link_libraries(nrfxlib_crypto INTERFACE ${OBERON_LIB})
 endif()
 
 if (CONFIG_NRF_CC310_BL)
@@ -34,8 +34,8 @@ if (CONFIG_NRF_CC310_BL)
     message(WARNING "This combination of SoC, floating point ABI, and interrupts settings is not supported by the nrf_cc310_bl lib."
                     "(${CC310_BL_LIB} doesn't exist.)")
   endif()
-  target_include_directories(${IMAGE}nrfxlib_crypto INTERFACE ${CC310_BL_BASE}/include)
-  target_link_libraries(${IMAGE}nrfxlib_crypto INTERFACE ${CC310_BL_LIB})
+  target_include_directories(nrfxlib_crypto INTERFACE ${CC310_BL_BASE}/include)
+  target_link_libraries(nrfxlib_crypto INTERFACE ${CC310_BL_LIB})
 endif()
 
 if (CONFIG_NRF_CC310_PLATFORM)
@@ -55,12 +55,12 @@ if (CONFIG_NRF_CC310_PLATFORM)
   #
   # Uses a normal add_library to avoid --whole-archive
   #
-  add_library(${IMAGE}platform_cc310 STATIC IMPORTED GLOBAL)
-  set_target_properties(${IMAGE}platform_cc310 PROPERTIES IMPORTED_LOCATION
+  add_library(platform_cc310 STATIC IMPORTED GLOBAL)
+  set_target_properties(platform_cc310 PROPERTIES IMPORTED_LOCATION
       "${NRF_CC310_PLATFORM_LIB}")
-  target_include_directories(${IMAGE}platform_cc310 INTERFACE
+  target_include_directories(platform_cc310 INTERFACE
       "${NRF_CC310_PLATFORM_BASE}/include")
-  zephyr_link_libraries(${IMAGE}platform_cc310)
+  zephyr_link_libraries(platform_cc310)
   #
   # Add companion sources to directly to zephyr
   #
@@ -81,13 +81,13 @@ if (CONFIG_CC310_BACKEND)
     message(WARNING "This combination of SoC, floating point ABI, and interrupts settings is not supported by the nrf_cc310_mbedcryto lib."
                     "(${NRF_CC310_LIB} doesn't exist.)")
   endif()
-  add_library(${IMAGE}mbedcrypto_cc310 STATIC IMPORTED GLOBAL)
-  set_target_properties(${IMAGE}mbedcrypto_cc310 PROPERTIES IMPORTED_LOCATION
+  add_library(mbedcrypto_cc310 STATIC IMPORTED GLOBAL)
+  set_target_properties(mbedcrypto_cc310 PROPERTIES IMPORTED_LOCATION
                         "${NRF_CC310_LIB}")
-  target_include_directories(${IMAGE}mbedcrypto_cc310 INTERFACE
+  target_include_directories(mbedcrypto_cc310 INTERFACE
                              "${NRF_CC310_BASE}/include"
                              "${NRF_CC310_BASE}/include/mbedtls")
-  target_link_libraries(${IMAGE}mbedcrypto_cc310 INTERFACE ${IMAGE}platform_cc310)
+  target_link_libraries(mbedcrypto_cc310 INTERFACE platform_cc310)
   if (NOT CONFIG_NRF_CRYPTO_BACKEND_COMBINATION_0)
     # Only CC310 backend is selected for mbedtls API.
     # Thus export the alt headers through Zephyr interface library.

--- a/nrf_security/CMakeLists.txt
+++ b/nrf_security/CMakeLists.txt
@@ -19,10 +19,10 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/symbol_rename.cmake)
 # directories
 #
 zephyr_interface_library_named(mbedtls_common)
-target_compile_definitions(${IMAGE}mbedtls_common INTERFACE
+target_compile_definitions(mbedtls_common INTERFACE
   -DMBEDTLS_CONFIG_FILE="${CONFIG_MBEDTLS_CFG_FILE}"
 )
-target_include_directories(${IMAGE}mbedtls_common INTERFACE
+target_include_directories(mbedtls_common INTERFACE
   ${generated_includes}
 )
 

--- a/nrf_security/cmake/symbol_rename.cmake
+++ b/nrf_security/cmake/symbol_rename.cmake
@@ -110,7 +110,7 @@ function(symbol_rename_func backend rename_template is_stripped)
 
   set(redefine_line "--redefine-syms;${CMAKE_CURRENT_BINARY_DIR}/symbol_rename_${MBEDTLS_BACKEND_PREFIX}.txt")
 
-  set(BACKEND_RENAMED_LIBRARY lib${IMAGE}mbedcrypto_${MBEDTLS_BACKEND_PREFIX}_backend.a)
+  set(BACKEND_RENAMED_LIBRARY libmbedcrypto_${MBEDTLS_BACKEND_PREFIX}_backend.a)
 
   if (remove_line)
     set(remove_object_command ${CMAKE_AR} d ${BACKEND_RENAMED_LIBRARY} ${remove_line})
@@ -120,21 +120,21 @@ function(symbol_rename_func backend rename_template is_stripped)
   add_custom_command(
     OUTPUT  ${BACKEND_RENAMED_LIBRARY}
     COMMAND ${CMAKE_OBJCOPY} ${redefine_line}
-            $<TARGET_FILE:${IMAGE}mbedcrypto_${MBEDTLS_BACKEND_PREFIX}>
+            $<TARGET_FILE:mbedcrypto_${MBEDTLS_BACKEND_PREFIX}>
             ${BACKEND_RENAMED_LIBRARY}
     COMMAND ${remove_object_command}
-    DEPENDS ${IMAGE}mbedcrypto_${MBEDTLS_BACKEND_PREFIX}
+    DEPENDS mbedcrypto_${MBEDTLS_BACKEND_PREFIX}
             ${CMAKE_CURRENT_BINARY_DIR}/symbol_rename_${MBEDTLS_BACKEND_PREFIX}.txt
   )
-  add_custom_target(${IMAGE}${MBEDTLS_BACKEND_PREFIX}_backend_target
+  add_custom_target(${MBEDTLS_BACKEND_PREFIX}_backend_target
                     DEPENDS ${BACKEND_RENAMED_LIBRARY}
   )
-  add_library(${IMAGE}mbedcrypto_${MBEDTLS_BACKEND_PREFIX}_backend STATIC IMPORTED GLOBAL)
-  add_dependencies(${IMAGE}mbedcrypto_${MBEDTLS_BACKEND_PREFIX}_backend
-                   ${IMAGE}${MBEDTLS_BACKEND_PREFIX}_backend_target)
-  set_target_properties(${IMAGE}mbedcrypto_${MBEDTLS_BACKEND_PREFIX}_backend
+  add_library(mbedcrypto_${MBEDTLS_BACKEND_PREFIX}_backend STATIC IMPORTED GLOBAL)
+  add_dependencies(mbedcrypto_${MBEDTLS_BACKEND_PREFIX}_backend
+                   ${MBEDTLS_BACKEND_PREFIX}_backend_target)
+  set_target_properties(mbedcrypto_${MBEDTLS_BACKEND_PREFIX}_backend
                         PROPERTIES IMPORTED_LOCATION
                         "${CMAKE_CURRENT_BINARY_DIR}/${BACKEND_RENAMED_LIBRARY}")
 
-  zephyr_append_cmake_library(${IMAGE}mbedcrypto_${MBEDTLS_BACKEND_PREFIX}_backend)
+  zephyr_append_cmake_library(mbedcrypto_${MBEDTLS_BACKEND_PREFIX}_backend)
 endfunction()

--- a/nrf_security/src/mbedcrypto_glue/CMakeLists.txt
+++ b/nrf_security/src/mbedcrypto_glue/CMakeLists.txt
@@ -11,8 +11,8 @@ if(CONFIG_NRF_CRYPTO_GLUE_LIBRARY)
   # Create a library with common compilation options and include folders
   #
   zephyr_interface_library_named(mbedtls_common_glue)
-  target_include_directories(${IMAGE}mbedtls_common_glue INTERFACE "${NRF_SECURITY_ROOT}/include/mbedcrypto_glue")
-  target_link_libraries(${IMAGE}mbedtls_common_glue INTERFACE ${IMAGE}mbedtls_common)
+  target_include_directories(mbedtls_common_glue INTERFACE "${NRF_SECURITY_ROOT}/include/mbedcrypto_glue")
+  target_link_libraries(mbedtls_common_glue INTERFACE mbedtls_common)
 
 
   if(CONFIG_GLUE_MBEDTLS_AES_C)
@@ -39,8 +39,8 @@ if(CONFIG_NRF_CRYPTO_GLUE_LIBRARY)
   zephyr_library_sources_ifdef(CONFIG_GLUE_MBEDTLS_CCM_C    ccm_alt.c)
   zephyr_library_sources_ifdef(CONFIG_GLUE_MBEDTLS_DHM_C    dhm_alt.c)
 
-  zephyr_library_link_libraries(${IMAGE}mbedtls_common_glue)
-  nrf_security_debug_list_target_files(${IMAGE}mbedcrypto_glue)
+  zephyr_library_link_libraries(mbedtls_common_glue)
+  nrf_security_debug_list_target_files(mbedcrypto_glue)
 
   #
   # Create glue libraries for backends (if enabled)

--- a/nrf_security/src/mbedcrypto_glue/cc310/cc310_glue.cmake
+++ b/nrf_security/src/mbedcrypto_glue/cc310/cc310_glue.cmake
@@ -39,17 +39,17 @@ zephyr_library_sources_ifdef(GLUE_CC310_MBEDTLS_DHM_C
 zephyr_library_sources(${ZEPHYR_BASE}/misc/empty_file.c)
 
 zephyr_library_compile_definitions(MBEDTLS_BACKEND_PREFIX=cc310)
-zephyr_library_link_libraries(${IMAGE}mbedtls_common_glue)
-nrf_security_debug_list_target_files(${IMAGE}mbedcrypto_glue_cc310)
+zephyr_library_link_libraries(mbedtls_common_glue)
+nrf_security_debug_list_target_files(mbedcrypto_glue_cc310)
 #
 # Rename the external symbols as referenced through the glue files
 # The APIs will match cc310_mbedtls_<xxxx> after this.
 #
 add_custom_command(
-  TARGET ${IMAGE}mbedcrypto_glue_cc310
+  TARGET mbedcrypto_glue_cc310
   POST_BUILD
   COMMAND ${CMAKE_OBJCOPY}
           --redefine-syms
           ${CMAKE_CURRENT_BINARY_DIR}/symbol_rename_cc310.txt
-          $<TARGET_FILE:${IMAGE}mbedcrypto_glue_cc310>
+          $<TARGET_FILE:mbedcrypto_glue_cc310>
 )

--- a/nrf_security/src/mbedcrypto_glue/vanilla/vanilla_glue.cmake
+++ b/nrf_security/src/mbedcrypto_glue/vanilla/vanilla_glue.cmake
@@ -27,43 +27,43 @@ nrf_security_debug("######### Creating vanilla noglue library #########")
 # This must use be compiled with its own config-file (nrf-config-noglue.h)
 # This library must not be linked with directly
 #
-add_library(${IMAGE}mbedcrypto_vanilla)
+add_library(mbedcrypto_vanilla)
 
 #
 # Adding all standard compile/linker options (e.g. float ABI)
 #
-target_compile_options(${IMAGE}mbedcrypto_vanilla PRIVATE ${TOOLCHAIN_C_FLAGS})
-target_ld_options(${IMAGE}mbedcrypto_vanilla PRIVATE ${TOOLCHAIN_LD_FLAGS})
+target_compile_options(mbedcrypto_vanilla PRIVATE ${TOOLCHAIN_C_FLAGS})
+target_ld_options(mbedcrypto_vanilla PRIVATE ${TOOLCHAIN_LD_FLAGS})
 
 #
 # Adding original mbed TLS files
 #
 target_sources_ifdef(GLUE_VANILLA_MBEDTLS_AES_C
-  ${IMAGE}mbedcrypto_vanilla PRIVATE ${ARM_MBEDTLS_PATH}/library/aes.c
+  mbedcrypto_vanilla PRIVATE ${ARM_MBEDTLS_PATH}/library/aes.c
 )
 target_sources_ifdef(GLUE_VANILLA_MBEDTLS_CCM_C
-  ${IMAGE}mbedcrypto_vanilla PRIVATE ${ARM_MBEDTLS_PATH}/library/ccm.c
+  mbedcrypto_vanilla PRIVATE ${ARM_MBEDTLS_PATH}/library/ccm.c
 )
 
 target_sources_ifdef(GLUE_VANILLA_MBEDTLS_DHM_C
-${IMAGE}mbedcrypto_vanilla PRIVATE ${ARM_MBEDTLS_PATH}/library/dhm.c
+mbedcrypto_vanilla PRIVATE ${ARM_MBEDTLS_PATH}/library/dhm.c
 )
 
-target_sources(${IMAGE}mbedcrypto_vanilla PRIVATE
+target_sources(mbedcrypto_vanilla PRIVATE
   ${ZEPHYR_BASE}/misc/empty_file.c
 )
 
-target_include_directories(${IMAGE}mbedcrypto_vanilla PRIVATE
+target_include_directories(mbedcrypto_vanilla PRIVATE
   ${common_includes}
   ${config_include}
 )
 
-target_compile_definitions(${IMAGE}mbedcrypto_vanilla PRIVATE
+target_compile_definitions(mbedcrypto_vanilla PRIVATE
   -DMBEDTLS_BACKEND_PREFIX=vanilla
   -DMBEDTLS_CONFIG_FILE="nrf-config-noglue.h"
 )
 
-nrf_security_debug_list_target_files(${IMAGE}mbedcrypto_vanilla)
+nrf_security_debug_list_target_files(mbedcrypto_vanilla)
 
 nrf_security_debug("######### Creating vanilla glue library #########")
 
@@ -89,21 +89,21 @@ zephyr_library_sources_ifdef(GLUE_VANILLA_MBEDTLS_DHM_C
 
 zephyr_library_sources(${ZEPHYR_BASE}/misc/empty_file.c)
 zephyr_library_compile_definitions(MBEDTLS_BACKEND_PREFIX=vanilla)
-zephyr_library_link_libraries(${IMAGE}mbedtls_common_glue)
-zephyr_library_link_libraries(${IMAGE}mbedcrypto_vanilla)
-nrf_security_debug_list_target_files(${IMAGE}mbedcrypto_glue_vanilla)
+zephyr_library_link_libraries(mbedtls_common_glue)
+zephyr_library_link_libraries(mbedcrypto_vanilla)
+nrf_security_debug_list_target_files(mbedcrypto_glue_vanilla)
 
 #
 # Rename vanilla symbols in for glue and vanilla library
 #
 foreach(mbedcrypto_target mbedcrypto_glue_vanilla mbedcrypto_vanilla)
   add_custom_command(
-    TARGET ${IMAGE}${mbedcrypto_target}
+    TARGET ${mbedcrypto_target}
     POST_BUILD
     COMMAND ${CMAKE_OBJCOPY}
             --redefine-syms
             ${CMAKE_CURRENT_BINARY_DIR}/symbol_rename_vanilla.txt
-            $<TARGET_FILE:${IMAGE}${mbedcrypto_target}>
+            $<TARGET_FILE:${mbedcrypto_target}>
   )
 endforeach()
 

--- a/nrf_security/src/mbedtls/CMakeLists.txt
+++ b/nrf_security/src/mbedtls/CMakeLists.txt
@@ -189,8 +189,8 @@ if(CONFIG_SOC_NRF52840 OR CONFIG_SOC_NRF9160)
 else()
   zephyr_library_sources(${NRF_SECURITY_ROOT}/src/backend/nrf5x/entropy_nrf5x.c)
 endif()
-zephyr_library_link_libraries(${IMAGE}mbedtls_common)
-nrf_security_debug_list_target_files(${IMAGE}mbedtls_base_vanilla)
+zephyr_library_link_libraries(mbedtls_common)
+nrf_security_debug_list_target_files(mbedtls_base_vanilla)
 
 #
 # Library for x.509
@@ -198,8 +198,8 @@ nrf_security_debug_list_target_files(${IMAGE}mbedtls_base_vanilla)
 if (CONFIG_MBEDTLS_X509_LIBRARY)
   zephyr_library_named(mbedtls_x509_vanilla)
   zephyr_library_sources(${src_x509})
-  zephyr_library_link_libraries(${IMAGE}mbedtls_common)
-  nrf_security_debug_list_target_files(${IMAGE}mbedtls_x509_vanilla)
+  zephyr_library_link_libraries(mbedtls_common)
+  nrf_security_debug_list_target_files(mbedtls_x509_vanilla)
   zephyr_library_app_memory(k_mbedtls_partition)
 endif()
 
@@ -209,8 +209,8 @@ endif()
 if (CONFIG_MBEDTLS_TLS_LIBRARY)
   zephyr_library_named(mbedtls_tls_vanilla)
   zephyr_library_sources(${src_tls} ${src_tls_replacement})
-  zephyr_library_link_libraries(${IMAGE}mbedtls_common)
-  nrf_security_debug_list_target_files(${IMAGE}mbedtls_tls_vanilla)
+  zephyr_library_link_libraries(mbedtls_common)
+  nrf_security_debug_list_target_files(mbedtls_tls_vanilla)
   zephyr_library_app_memory(k_mbedtls_partition)
 endif()
 
@@ -219,21 +219,21 @@ if(NOT CONFIG_NRF_CRYPTO_BACKEND_COMBINATION_0)
   # Only single backend is chosen, thus append it to zephyr libraries as
   # no renaming should be carried out.
   #
-  if(TARGET ${IMAGE}mbedcrypto_cc310)
-    target_link_libraries(${IMAGE}mbedtls_base_vanilla PRIVATE ${IMAGE}mbedcrypto_cc310)
+  if(TARGET mbedcrypto_cc310)
+    target_link_libraries(mbedtls_base_vanilla PRIVATE mbedcrypto_cc310)
   endif()
-  if(TARGET ${IMAGE}platform_cc310)
-    target_link_libraries(${IMAGE}mbedtls_base_vanilla PRIVATE ${IMAGE}platform_cc310)
+  if(TARGET platform_cc310)
+    target_link_libraries(mbedtls_base_vanilla PRIVATE platform_cc310)
   endif()
 endif()
 
 
 #
-# Generate a dummy library called ${IMAGE}mbedtls_external to be able to use
+# Generate a dummy library called mbedtls_external to be able to use
 # CONFIG_MBEDTLS and CONFIG_MBEDTLS_LIBRARY in zephyr sockets
 #
-add_library(${IMAGE}mbedtls_external)
-target_sources(${IMAGE}mbedtls_external PRIVATE ${ZEPHYR_BASE}/misc/empty_file.c)
+add_library(mbedtls_external)
+target_sources(mbedtls_external PRIVATE ${ZEPHYR_BASE}/misc/empty_file.c)
 
 #
 # Give the main application access to the generated includes and mbed TLS config
@@ -242,9 +242,9 @@ target_sources(${IMAGE}mbedtls_external PRIVATE ${ZEPHYR_BASE}/misc/empty_file.c
 #       which is always set to "true".
 #
 zephyr_interface_library_named(mbedtls_includes)
-target_link_libraries(${IMAGE}mbedtls_includes INTERFACE ${IMAGE}mbedtls_common)
+target_link_libraries(mbedtls_includes INTERFACE mbedtls_common)
 
 #
 # Give zephyr libraries access to includes and mbed TLS config
 #
-zephyr_link_libraries(${IMAGE}mbedtls_common)
+zephyr_link_libraries(mbedtls_common)


### PR DESCRIPTION
All occurrences of ${IMAGE} have been removed in order to adopt to the
new strategy used for multi image builds.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>