### PR TITLE
Kconfig: ble_controller: Update to upstream Kconfig support configs.

### DIFF
--- a/ble_controller/Kconfig
+++ b/ble_controller/Kconfig
@@ -16,6 +16,13 @@ choice BT_LL_CHOICE
 config BT_LL_NRFXLIB
 	bool "Nordic proprietary BLE Link Layer"
 	select ZERO_LATENCY_IRQS
+	select BT_CTLR_LE_ENC_SUPPORT
+	select BT_CTLR_EXT_REJ_IND_SUPPORT
+	select BT_CTLR_SLAVE_FEAT_REQ_SUPPORT
+	select BT_CTLR_PRIVACY_SUPPORT
+	select BT_CTLR_EXT_SCAN_FP_SUPPORT
+	select BT_CTLR_PHY_UPDATE_SUPPORT
+	select BT_CTLR_CHAN_SEL_2_SUPPORT
 	# This controller only supports nRF52, it does not support 51 or
 	# 91 (91 doesn't even have the physical HW needed for BLE).
 	depends on SOC_SERIES_NRF52X
@@ -34,7 +41,7 @@ choice BLE_CONTROLLER_VARIANT
 	default BLE_CONTROLLER_S132 if SOC_NRF52832
 	default BLE_CONTROLLER_S140 if SOC_NRF52840
 	help
-		Select a BLE Controller variant.
+	  Select a BLE Controller variant.
 
 config BLE_CONTROLLER_S112
 	depends on (SOC_NRF52810 || SOC_NRF52811 || SOC_NRF52832)
@@ -43,9 +50,13 @@ config BLE_CONTROLLER_S112
 config BLE_CONTROLLER_S132
 	depends on (SOC_NRF52810 || SOC_NRF52832)
 	bool "s132"
+	select BT_CTLR_DATA_LEN_UPDATE_SUPPORT
+	select BT_CTLR_ADV_EXT_SUPPORT
 
 config BLE_CONTROLLER_S140
 	depends on (SOC_NRF52811 || SOC_NRF52840)
+	select BT_CTLR_DATA_LEN_UPDATE_SUPPORT
+	select BT_CTLR_ADV_EXT_SUPPORT
 	bool "s140"
 
 endchoice


### PR DESCRIPTION
Add Kconfig support configuration symbols to BLE controller for so that
dependent configurations can be set from this. This enables features
in the host e.g. PHY update.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>