### PR TITLE
mpsl: Enable zero latency IRQs for MPSL

### DIFF
--- a/mpsl/Kconfig
+++ b/mpsl/Kconfig
@@ -7,6 +7,7 @@
 config MPSL
 	bool "Nordic Multi Protocol Service Layer (MPSL)"
 	# MPSL only supports nRF52, it does not support 51 or 91.
+	select ZERO_LATENCY_IRQS
 	depends on SOC_SERIES_NRF52X
 	help
 	  Use Nordic Multi Protocol Service Layer (MPSL) implementation,


### PR DESCRIPTION
Select ZERO_LATENCY_IRQS in Kconfig for MPSL library so that the IRQs
can be connected with the IRQ_ZERO_LATENCY flag. When this flag is
used, ISRs cannot be blocked by irq_lock.

Signed-off-by: Solveig Fure <Solveig.Fure@nordicsemi.no>