### PR TITLE
nrf_security: Fixing wchar_t support in generated libraries

### DIFF
--- a/nrf_security/src/mbedcrypto_glue/CMakeLists.txt
+++ b/nrf_security/src/mbedcrypto_glue/CMakeLists.txt
@@ -32,6 +32,8 @@ if(CONFIG_NRF_CRYPTO_GLUE_LIBRARY)
   #
   zephyr_library_named(mbedcrypto_glue)
 
+  zephyr_library_compile_options_ifdef(CONFIG_SHORT_WCHAR_T -fshort-wchar)
+
   #
   # Add glued files if enabled
   #

--- a/nrf_security/src/mbedcrypto_glue/cc310/cc310_glue.cmake
+++ b/nrf_security/src/mbedcrypto_glue/cc310/cc310_glue.cmake
@@ -23,6 +23,8 @@ endif()
 
 zephyr_library_named(mbedcrypto_glue_cc310)
 
+zephyr_library_compile_options_ifdef(CONFIG_SHORT_WCHAR_T -fshort-wchar)
+
 #
 # Adding cc310 backend glue files
 #

--- a/nrf_security/src/mbedcrypto_glue/vanilla/vanilla_glue.cmake
+++ b/nrf_security/src/mbedcrypto_glue/vanilla/vanilla_glue.cmake
@@ -29,6 +29,10 @@ nrf_security_debug("######### Creating vanilla noglue library #########")
 #
 add_library(${IMAGE}mbedcrypto_vanilla)
 
+if (CONFIG_SHORT_WCHAR_T)
+  target_compile_options(${IMAGE}mbedcrypto_vanilla PRIVATE -fshort-wchar)
+endif()
+
 #
 # Adding all standard compile/linker options (e.g. float ABI)
 #
@@ -71,6 +75,8 @@ nrf_security_debug("######### Creating vanilla glue library #########")
 # Create the vanilla glue library
 #
 zephyr_library_named(mbedcrypto_glue_vanilla)
+
+zephyr_library_compile_options_ifdef(CONFIG_SHORT_WCHAR_T -fshort-wchar)
 
 #
 # Adding vanilla backend glue files

--- a/nrf_security/src/mbedtls/CMakeLists.txt
+++ b/nrf_security/src/mbedtls/CMakeLists.txt
@@ -130,6 +130,7 @@ zephyr_include_directories(${common_includes})
 # Library containing code not in Glue or backend
 #
 zephyr_library_named(mbedtls_base_vanilla)
+zephyr_library_compile_options_ifdef(CONFIG_SHORT_WCHAR_T -fshort-wchar)
 zephyr_library_sources(${src_crypto} ${src_crypto_replacement})
 
 #
@@ -197,6 +198,7 @@ nrf_security_debug_list_target_files(${IMAGE}mbedtls_base_vanilla)
 #
 if (CONFIG_MBEDTLS_X509_LIBRARY)
   zephyr_library_named(mbedtls_x509_vanilla)
+  zephyr_library_compile_options_ifdef(CONFIG_SHORT_WCHAR_T -fshort-wchar)
   zephyr_library_sources(${src_x509})
   zephyr_library_link_libraries(${IMAGE}mbedtls_common)
   nrf_security_debug_list_target_files(${IMAGE}mbedtls_x509_vanilla)
@@ -208,6 +210,7 @@ endif()
 #
 if (CONFIG_MBEDTLS_TLS_LIBRARY)
   zephyr_library_named(mbedtls_tls_vanilla)
+  zephyr_library_compile_options_ifdef(CONFIG_SHORT_WCHAR_T -fshort-wchar)
   zephyr_library_sources(${src_tls} ${src_tls_replacement})
   zephyr_library_link_libraries(${IMAGE}mbedtls_common)
   nrf_security_debug_list_target_files(${IMAGE}mbedtls_tls_vanilla)
@@ -233,6 +236,9 @@ endif()
 # CONFIG_MBEDTLS and CONFIG_MBEDTLS_LIBRARY in zephyr sockets
 #
 add_library(${IMAGE}mbedtls_external)
+if (CONFIG_SHORT_WCHAR_T)
+  target_compile_options(${IMAGE}mbedtls_external PRIVATE -fshort-wchar)
+endif()
 target_sources(${IMAGE}mbedtls_external PRIVATE ${ZEPHYR_BASE}/misc/empty_file.c)
 
 #
@@ -242,6 +248,7 @@ target_sources(${IMAGE}mbedtls_external PRIVATE ${ZEPHYR_BASE}/misc/empty_file.c
 #       which is always set to "true".
 #
 zephyr_interface_library_named(mbedtls_includes)
+zephyr_library_compile_options_ifdef(CONFIG_SHORT_WCHAR_T -fshort-wchar)
 target_link_libraries(${IMAGE}mbedtls_includes INTERFACE ${IMAGE}mbedtls_common)
 
 #


### PR DESCRIPTION
-Add -fshort-wchar for all libraries generated by nrf_security build

Ref: NCSDK-3820

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>