### PR TITLE
CODEOWNERS: Add codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,28 @@
+# CODEOWNERS for autoreview assigning in github
+
+# Order is important; the last matching pattern takes the most
+# precedence.
+
+# Root folder
+/CODEOWNERS                               @carlescufi
+/LICENSE                                  @carlescufi
+/Jenkinsfile                              @carlescufi
+/README.rst                               @ru-fu @carlescufi
+
+# All cmake related files
+/CMakeLists.txt                           @SebastianBoe
+
+# All Kconfig related files
+Kconfig*                                  @SebastianBoe
+
+# All documentation related files
+*.rst                                     @b-gent
+
+# All subfolders
+/ble_controller/                          @joerchan @rugeGerritsen
+/bsdlib/                                  @rlubos @lemrey @evenl
+/crypto/                                  @frkv @tejlmand
+/mpsl/                                    @joerchan @rugeGerritsen
+/nfc/                                     @anangl @grochu
+/nrf_security/                            @frkv @tejlmand
+/zephyr/                                  @carlescufi


### PR DESCRIPTION
Add codeowners file to auto-assign reviewers.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>