### PR TITLE
crypto: cc310: Update path in inclusion of Zephyr's reboot.h

### DIFF
--- a/crypto/nrf_cc310_platform/src/nrf_cc310_platform_abort_zephyr.c
+++ b/crypto/nrf_cc310_platform/src/nrf_cc310_platform_abort_zephyr.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 #include <kernel.h>
-#include <misc/reboot.h>
+#include <power/reboot.h>
 //#include <logging/log.h>
 //LOG_MODULE_DECLARE(cc310_platform);
 


### PR DESCRIPTION
The file has been moved from misc/ to power/. Update its inclusion
accordingly.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>