### PR TITLE
ci: use nRF manifest to get ci-tools repo

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,19 @@
+name: Backport
+on:
+  pull_request:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    runs-on: ubuntu-18.04
+    name: Backport
+    steps:
+      - name: Backport Bot
+        uses: Gaurav0/backport@v1.0.24
+        with:
+          bot_username: NordicBuilder
+          bot_token: 151a9b45052f9ee8be5a59963d31ad7b92c3ecb5
+          bot_token_key: 67bb1f1f998d546859786a4088917c65415c0ebd
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,7 @@
 # Root folder
 /CODEOWNERS                               @carlescufi
 /LICENSE                                  @carlescufi
-/Jenkinsfile                              @carlescufi
+/Jenkinsfile                              @thst-nordic
 /README.rst                               @ru-fu @carlescufi
 
 # All cmake related files
@@ -19,6 +19,7 @@ Kconfig*                                  @SebastianBoe
 *.rst                                     @b-gent
 
 # All subfolders
+/.github/                                 @thst-nordic
 /ble_controller/                          @joerchan @rugeGerritsen
 /bsdlib/                                  @rlubos @lemrey @evenl
 /crypto/                                  @frkv @tejlmand


### PR DESCRIPTION
 - nrf/master:HEAD is used by default
 - Add common CRON functionality
 - update Jenkinsfile for CI_LIB v2
 - Add entry to CODEOWNERS
 - Add Github-Actions:BackPortBot

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>