### PR TITLE
nrf_socket: document limitations of nrf_getaddrinfo

### DIFF
--- a/bsdlib/include/nrf_socket.h
+++ b/bsdlib/include/nrf_socket.h
@@ -1248,9 +1248,12 @@ const char * nrf_inet_ntop(int             family,
  *
  * @param[in]  p_node     Host name to resolve.
  * @param[in]  p_service  Service to resolve.
- * @param[in]  p_hints    Any hints to be used for the resolution.
+ * @param[in]  p_hints    Any hints to be used for the resolution,
+ *                        for example, whether the address is IPv4 or IPv6.
  * @param[out] pp_res     Pointer to the linked list of resolved addresses if the procedure
  *                        was successful.
+ *                        Note that because of limitations in the modem,
+ *                        only one address is returned.
  *
  * @return 0 if the procedure succeeds, else, an errno indicating the reason for failure.
  */


### PR DESCRIPTION
nrf_getaddrinfo returns only one address at the moment, not a
list of addresses.
Also clarified what the hint parameter contains.

See https://projecttools.nordicsemi.no/jira/browse/NCSDK-1952.

Note that this function is not displayed in the documentation output. See https://projecttools.nordicsemi.no/jira/browse/NCSIDB-16 