### PR TITLE
doc: README: Remove kconfig/index from toctree

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,4 +22,3 @@ Semiconductor. Refer to their respective documentation for more information.
    mpsl/README
    nrf_security/README
    nfc/README
-   kconfig/index


### PR DESCRIPTION
The Kconfig documentation will be shared and in a separate documentation
set once https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/1258
is in.

This commit should be merged together with that PR. It's fine to merge
it slightly after though, because this is just fixing a warning.