### PR TITLE
nrf_security: crypto improvements post Q1 release

### DIFF
--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -147,17 +147,37 @@ config MBEDTLS_CIPHER_AES_256_OFB_C
 
 comment "Configuration section"
 
-config NRF_SECURITY_RNG
+menuconfig NRF_SECURITY_RNG
 	bool
 	prompt "Random Number Generator support"
 	default y
-	select MBEDTLS_AES_C
 	select MBEDTLS_SHA256_C
 	help
 	  The Random Number Generator support in nRF Security provides a
 	  Pseudorandom Number Generator, PRNG.
 	  The Pseudorandom Number Generator is seeded by a True Random Number
 	  Generator, TRNG, available in hardware.
+
+if NRF_SECURITY_RNG
+
+config MBEDTLS_CTR_DRBG_C
+	bool
+	prompt "PRNG using CTR_DRBG"
+	default y
+	select MBEDTLS_AES_C
+	help
+	  This setting will enable CTR_DRBG APIs in mbed TLS.
+	  Corresponds to MBEDTLS_CTR_DRBG_C setting in mbed TLS config file.
+
+config MBEDTLS_HMAC_DRBG_C
+	bool
+	prompt "PRNG using HMAC_DRBG"
+	default y
+	help
+	  This setting will enable HMAC_DRBG APIs in mbed TLS.
+	  Corresponds to MBEDTLS_HMAC_DRBG_C setting in mbed TLS config file.
+
+endif
 
 menuconfig MBEDTLS_AES_C
 	bool

--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -838,6 +838,27 @@ if NRF_SECURITY_ADVANCED
 
 comment "Advanced mbed TLS settings"
 
+config MBEDTLS_AES_ROM_TABLES
+	bool "Use AES ROM tables"
+	depends on VANILLA_MBEDTLS_AES_C || (MBEDTLS_VANILLA_BACKEND && MBEDTLS_AES_C)
+	help
+	  AES lookup tables will be placed in ROM instead of RAM
+	  Placing the AES lookup tables in ROM will perform slower but will reduce RAM usage.
+	  Using precompiled ROM tables reduces RAM size by ~8kB with an additional
+	  cost of ~8kB of ROM size.
+	  If MBEDTLS_AES_FEWER_TABLES is used the RAM reduction is ~2kB with an
+	  additional cost of ~2kB of ROM size.
+	  MBEDTLS_AES_ROM_TABLES setting in mbed TLS config file.
+
+config MBEDTLS_AES_FEWER_TABLES
+	bool "Use fewer AES tables"
+	depends on VANILLA_MBEDTLS_AES_C || (MBEDTLS_VANILLA_BACKEND && MBEDTLS_AES_C)
+	help
+	  Enabling this configuration omits 75% of the AES tables in ROM or RAM.
+	  There is a tradeoff between lookup size and doing more arithmetic
+	  operations on the fly, which impacts the performance of the AES operations.
+	  MBEDTLS_AES_FEWER_TABLES setting in mbed TLS config file.
+
 config MBEDTLS_MPI_WINDOW_SIZE
 	int "MPI - Multiple Precision Integers window size"
 	range 1 6

--- a/nrf_security/cmake/kconfig_mbedtls_configure.cmake
+++ b/nrf_security/cmake/kconfig_mbedtls_configure.cmake
@@ -110,7 +110,9 @@ kconfig_mbedtls_config("MBEDTLS_CIPHER_MODE_OFB")
 kconfig_mbedtls_config("MBEDTLS_CIPHER_MODE_XTS")
 kconfig_mbedtls_config("MBEDTLS_CMAC_C")
 kconfig_mbedtls_config("MBEDTLS_CCM_C")
+kconfig_mbedtls_config("MBEDTLS_CTR_DRBG_C")
 kconfig_mbedtls_config("MBEDTLS_DHM_C")
+kconfig_mbedtls_config("MBEDTLS_HMAC_DRBG_C")
 kconfig_mbedtls_config("MBEDTLS_SHA1_C")
 kconfig_mbedtls_config("MBEDTLS_SHA256_C")
 kconfig_mbedtls_config("MBEDTLS_SHA512_C")
@@ -334,6 +336,11 @@ mbedtls_config_define_depends("MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED"
   "MBEDTLS_ECJPAKE_C"
   "MBEDTLS_TLS_LIBRARY"
   "MBEDTLS_X509_LIBRARY"
+)
+
+mbedtls_config_define_depends("MBEDTLS_ECDSA_DETERMINISTIC"
+  "MBEDTLS_ECDSA_C"
+  "MBEDTLS_HMAC_DRBG_C"
 )
 
 set(generated_include_path

--- a/nrf_security/cmake/kconfig_mbedtls_configure.cmake
+++ b/nrf_security/cmake/kconfig_mbedtls_configure.cmake
@@ -101,6 +101,8 @@ file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/include/)
 # Enabling core functionality
 #
 kconfig_mbedtls_config("MBEDTLS_AES_C")
+kconfig_mbedtls_config("MBEDTLS_AES_ROM_TABLES")
+kconfig_mbedtls_config("MBEDTLS_AES_FEWER_TABLES")
 kconfig_mbedtls_config("MBEDTLS_CIPHER_MODE_CBC")
 kconfig_mbedtls_config("MBEDTLS_CIPHER_MODE_CFB")
 kconfig_mbedtls_config("MBEDTLS_CIPHER_MODE_CTR")

--- a/nrf_security/configs/nrf-config.h.template
+++ b/nrf_security/configs/nrf-config.h.template
@@ -497,7 +497,7 @@
  * This option is independent of \c MBEDTLS_AES_FEWER_TABLES.
  *
  */
-//#define MBEDTLS_AES_ROM_TABLES
+#cmakedefine MBEDTLS_AES_ROM_TABLES
 
 /**
  * \def MBEDTLS_AES_FEWER_TABLES
@@ -519,7 +519,7 @@
  * This option is independent of \c MBEDTLS_AES_ROM_TABLES.
  *
  */
-//#define MBEDTLS_AES_FEWER_TABLES
+#cmakedefine MBEDTLS_AES_FEWER_TABLES
 
 /**
  * \def MBEDTLS_CAMELLIA_SMALL_MEMORY

--- a/nrf_security/configs/nrf-config.h.template
+++ b/nrf_security/configs/nrf-config.h.template
@@ -690,7 +690,7 @@
  *
  * Comment this macro to disable deterministic ECDSA.
  */
-#define MBEDTLS_ECDSA_DETERMINISTIC
+#cmakedefine MBEDTLS_ECDSA_DETERMINISTIC
 
 /**
  * \def MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
@@ -2037,7 +2037,7 @@
  *
  * This module provides the CTR_DRBG AES-256 random number generator.
  */
-#define MBEDTLS_CTR_DRBG_C
+#cmakedefine MBEDTLS_CTR_DRBG_C
 
 /**
  * \def MBEDTLS_DEBUG_C
@@ -2257,7 +2257,7 @@
  *
  * Uncomment to enable the HMAC_DRBG random number geerator.
  */
-#define MBEDTLS_HMAC_DRBG_C
+#cmakedefine MBEDTLS_HMAC_DRBG_C
 
 /**
  * \def MBEDTLS_NIST_KW_C


### PR DESCRIPTION
- Adds minor changes postponed after Q1 release
- Enabling HMAC_DRBG as a configurable option in nrf_security
- Allowing mbed TLS AES to be configured to use ROM tables to conserve RAM

 Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>