### PR TITLE
codeowners: Transfer codeowner files from SebastianBoe to tejlmand

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,10 +10,10 @@
 /README.rst                               @ru-fu @carlescufi
 
 # All cmake related files
-/CMakeLists.txt                           @SebastianBoe
+/CMakeLists.txt                           @tejlmand
 
 # All Kconfig related files
-Kconfig*                                  @SebastianBoe
+Kconfig*                                  @tejlmand
 
 # All documentation related files
 *.rst                                     @b-gent


### PR DESCRIPTION
Transfer CODEOWNER file matches from SebastianBoe to tejlmand as
tejlmand is taking over the build and configuration system code owner
position.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>