### PR TITLE
nrf_security/src/mbedcrypto_glue/vanilla: fix BUILD_ASSERT_MSG macro

### DIFF
--- a/nrf_security/src/mbedcrypto_glue/vanilla/aes_vanilla.c
+++ b/nrf_security/src/mbedcrypto_glue/vanilla/aes_vanilla.c
@@ -17,9 +17,9 @@
 #include "aes_alt.h"
 #include "backend_aes.h"
 
-BUILD_ASSERT_MSG(VANILLA_MBEDTLS_AES_CONTEXT_WORDS == (sizeof(mbedtls_aes_context) - 4) / 4, "Invalid VANILLA_MBEDTLS_AES_CONTEXT_WORDS value");
+BUILD_ASSERT(VANILLA_MBEDTLS_AES_CONTEXT_WORDS == (sizeof(mbedtls_aes_context) - 4) / 4, "Invalid VANILLA_MBEDTLS_AES_CONTEXT_WORDS value");
 #if defined(CONFIG_GLUE_MBEDTLS_CIPHER_MODE_XTS) && defined(CONFIG_VANILLA_MBEDTLS_CIPHER_MODE_XTS)
-BUILD_ASSERT_MSG(VANILLA_MBEDTLS_AES_XTS_CONTEXT_WORDS == (sizeof(mbedtls_aes_xts_context) - 4) / 4, "Invalid VANILLA_MBEDTLS_AES_XTS_CONTEXT_WORDS value");
+BUILD_ASSERT(VANILLA_MBEDTLS_AES_XTS_CONTEXT_WORDS == (sizeof(mbedtls_aes_xts_context) - 4) / 4, "Invalid VANILLA_MBEDTLS_AES_XTS_CONTEXT_WORDS value");
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
 
 
@@ -67,4 +67,3 @@ const mbedtls_aes_funcs mbedtls_aes_vanilla_mbedtls_backend_funcs = {
 };
 
 #endif /* defined(CONFIG_VANILLA_MBEDTLS_AES_C) && defined(CONFIG_GLUE_MBEDTLS_AES_C) */
-

--- a/nrf_security/src/mbedcrypto_glue/vanilla/ccm_vanilla.c
+++ b/nrf_security/src/mbedcrypto_glue/vanilla/ccm_vanilla.c
@@ -18,7 +18,7 @@
 #include "backend_ccm.h"
 
 
-BUILD_ASSERT_MSG(VANILLA_MBEDTLS_CCM_CONTEXT_WORDS == (sizeof(mbedtls_cipher_context_t) + 3) / 4, "Invalid VANILLA_MBEDTLS_CCM_CONTEXT_WORDS value");
+BUILD_ASSERT(VANILLA_MBEDTLS_CCM_CONTEXT_WORDS == (sizeof(mbedtls_cipher_context_t) + 3) / 4, "Invalid VANILLA_MBEDTLS_CCM_CONTEXT_WORDS value");
 
 
 static int mbedtls_ccm_check(mbedtls_cipher_id_t cipher, unsigned int keybits)
@@ -39,4 +39,3 @@ const mbedtls_ccm_funcs mbedtls_ccm_vanilla_mbedtls_backend_funcs = {
 };
 
 #endif
-

--- a/nrf_security/src/mbedcrypto_glue/vanilla/rsa_vanilla.c
+++ b/nrf_security/src/mbedcrypto_glue/vanilla/rsa_vanilla.c
@@ -12,7 +12,7 @@
 #include "backend_rsa.h"
 
 
-BUILD_ASSERT_MSG(VANILLA_MBEDTLS_RSA_CONTEXT_WORDS  == (sizeof(mbedtls_rsa_context) + 3) / 4, "Invalid VANILLA_MBEDTLS_RSA_CONTEXT_WORDS value");
+BUILD_ASSERT(VANILLA_MBEDTLS_RSA_CONTEXT_WORDS  == (sizeof(mbedtls_rsa_context) + 3) / 4, "Invalid VANILLA_MBEDTLS_RSA_CONTEXT_WORDS value");
 
 
 static int mbedtls_rsa_check(int padding, int hash_id, unsigned int nbits)
@@ -74,4 +74,3 @@ const mbedtls_rsa_funcs mbedtls_rsa_vanilla_mbedtls_backend_funcs = {
 };
 
 #endif
-


### PR DESCRIPTION
Zephyr replaced BUILD_ASSERT_MSG by BUILD_ASSERT macro.

nedded for the upmereg
https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/2172

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>