### PR TITLE
kconfig: Update to FPU and FPU_SHARING renamed upstream

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -20,7 +20,7 @@ function(nrfxlib_calculate_lib_path lib_path)
   # Add Arch type
   assert(GCC_M_CPU "GCC_M_CPU must be set to find correct lib.")
   # Set floating ABI
-  if(CONFIG_FLOAT)
+  if(CONFIG_FPU)
     if(CONFIG_FP_HARDABI)
         set(float_dir hard-float)
     elseif(CONFIG_FP_SOFTABI)

--- a/crypto/Kconfig
+++ b/crypto/Kconfig
@@ -12,7 +12,7 @@ config NRF_OBERON
 config NRF_CC310_BL
 	bool "nrf_cc310_bl HW crypto library for nRF devices with CryptoCell CC310."
 	select NRFXLIB_CRYPTO
-	select FLOAT # The cc310_bl lib uses floating point registers.
+	select FPU # The cc310_bl lib uses floating point registers.
 	depends on !NORDIC_SECURITY_BACKEND
 	help
 	  To use, link with nrfxlib_crypto in CMake.


### PR DESCRIPTION
Update FLOAT and FP_SHARING to FPU and FPU_SHARING respectively
renamed upstream.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>